### PR TITLE
Run collectstatic when starting django dev runserver

### DIFF
--- a/apps/backend/conf/docker/dev.env
+++ b/apps/backend/conf/docker/dev.env
@@ -4,7 +4,7 @@ ALLOWED_HOSTS=127.0.0.1,0.0.0.0,localhost
 DJANGO_SETTINGS_MODULE=covsonar_backend.settings
 LOG_PATH=/logs
 PROPERTY_BATCH_SIZE=10000
-START_DJANGO_SERVER="python manage.py runserver 0.0.0.0:9080"
+START_DJANGO_SERVER="python manage.py collectstatic --noinput && python manage.py runserver 0.0.0.0:9080"
 
 # Profiling:
 # Enable this and "django_extensions" in settings.dev to enable per request

--- a/apps/backend/conf/nginx/templates/sonar.conf.template
+++ b/apps/backend/conf/nginx/templates/sonar.conf.template
@@ -19,7 +19,6 @@ server {
     alias /staticfiles/;
   }
 
-
   # Frontend
   location / {
     root /frontend;


### PR DESCRIPTION
For me this is enough to get the django admin interface css working, without any changes to the nginx config being necessary.