### PR TITLE
Change timezone of logging messages/containers from GMT to Berlin local

### DIFF
--- a/apps/backend/compose.yml
+++ b/apps/backend/compose.yml
@@ -125,6 +125,8 @@ services:
   sonar-cache:
     image: $DOCKER_REDIS_IMAGE
     container_name: sonar-cache
+    environment:
+      - TZ=$TIME_ZONE
     restart: unless-stopped
 
   celery-workers:

--- a/apps/backend/compose.yml
+++ b/apps/backend/compose.yml
@@ -14,6 +14,8 @@ services:
       # host's /var/lib/docker/volumes directory
       - ${POSTGRES_DATA_EXTERNAL}:/var/lib/postgresql/data
     environment:
+    - TZ=$TIME_ZONE
+    - PGTZ=$TIME_ZONE
     - POSTGRES_DB=$POSTGRES_DB
     - POSTGRES_SCHEMA=$POSTGRES_SCHEMA
     - POSTGRES_USER=$POSTGRES_USER
@@ -32,6 +34,7 @@ services:
     container_name: sonar-django-backend
     environment:
       - DEBUG=$DEBUG
+      - TZ=$TIME_ZONE
       - REDIS_URL=$REDIS_URL
       - SAMPLE_BATCH_SIZE=$SAMPLE_BATCH_SIZE
       - PROPERTY_BATCH_SIZE=$PROPERTY_BATCH_SIZE
@@ -70,6 +73,7 @@ services:
     container_name: sonar-django-apscheduler
     environment:
       - DEBUG=$DEBUG
+      - TZ=$TIME_ZONE
       - REDIS_URL=$REDIS_URL
       - SAMPLE_BATCH_SIZE=$SAMPLE_BATCH_SIZE
       - PROPERTY_BATCH_SIZE=$PROPERTY_BATCH_SIZE
@@ -110,6 +114,7 @@ services:
       # These are for the frontend
       - ./work/frontend/dist:/frontend
     environment:
+      - TZ=$TIME_ZONE
       - NGINX_PORT=8000
     ports:
       - "127.0.0.1:8000:8000"
@@ -135,6 +140,7 @@ services:
       - ${SONAR_EXTERNAL}/data:${SONAR_DATA_FOLDER}
     environment:
       - DEBUG=$DEBUG
+      - TZ=$TIME_ZONE
       - REDIS_URL=$REDIS_URL
       - SAMPLE_BATCH_SIZE=$SAMPLE_BATCH_SIZE
       - PROPERTY_BATCH_SIZE=$PROPERTY_BATCH_SIZE
@@ -165,6 +171,7 @@ services:
     command: celery -A covsonar_backend flower --port=5555 --basic_auth="$CELERY_FLOWER_AUTH" --enable_events=False
     environment:
       - DEBUG=$DEBUG
+      - TZ=$TIME_ZONE
       - REDIS_URL=$REDIS_URL
       - SAMPLE_BATCH_SIZE=$SAMPLE_BATCH_SIZE
       - PROPERTY_BATCH_SIZE=$PROPERTY_BATCH_SIZE

--- a/apps/backend/conf/docker/common.env
+++ b/apps/backend/conf/docker/common.env
@@ -2,6 +2,8 @@
 # Default this to FALSE, and set it to TRUE in dev env file
 DEBUG=FALSE
 
+TIME_ZONE=Europe/Berlin
+
 # Path to directories inside the sonar container
 SONAR_DATA_FOLDER="/sonar/data"
 SONAR_DATA_ENTRY_FOLDER="/sonar/data/import"

--- a/apps/backend/covsonar_backend/settings.py
+++ b/apps/backend/covsonar_backend/settings.py
@@ -35,6 +35,7 @@ env = environ.Env(
     ALLOWED_HOSTS=(str, None),
     SAMPLE_BATCH_SIZE=(int, 10),
     PROPERTY_BATCH_SIZE=(int, 1000),
+    TIME_ZONE=(str, "UTC"),
 )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -164,7 +165,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = env("TIME_ZONE")
 
 USE_I18N = True
 
@@ -268,6 +269,7 @@ CACHES = {
 # Celery settings
 CELERY_BROKER_URL = f"{env('REDIS_URL')}0"
 CELERY_RESULT_BACKEND = f"{env('REDIS_URL')}0"
+CELERY_ENABLE_UTC = False
 
 if DEBUG:
     INTERNAL_IPS = ("127.0.0.1",)


### PR DESCRIPTION
This is just to reduce confusion when looking at logs and also when setting the time for recurring jobs.

I hoped this would be easy but there are application-specific settings for timezones for nearly every application and library we are using. Ugh.

Still needs to be fixed:

- [x] sonar-cache
- [x] sonar-db
- [ ] celery
- [ ] backend
(basically everything!)

```
sonar-cache               | 1:M 04 Nov 2024 10:01:15.230 * monotonic clock: POSIX clock_gettime
sonar-cache               | 1:M 04 Nov 2024 10:01:15.230 * Running mode=standalone, port=6379.
sonar-cache               | 1:M 04 Nov 2024 10:01:15.230 * Server initialized
sonar-cache               | 1:M 04 Nov 2024 10:01:15.230 * Ready to accept connections tcp
sonar-db                  | 2024-11-04 10:01:15.256 GMT [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.8432"
sonar-db                  | 2024-11-04 10:01:15.273 GMT [29] LOG:  database system was shut down at 2024-11-04 10:00:17 GMT
sonar-db                  | 2024-11-04 10:01:15.285 GMT [1] LOG:  database system is ready to accept connections
sonar-django-backend      | Watching for file changes with StatReloader
sonar-django-backend      | Watching for file changes with StatReloader
sonar-django-backend      | System check identified no issues (0 silenced).
sonar-django-backend      | November 04, 2024 - 10:01:24
sonar-django-backend      | Django version 4.2.10, using settings 'covsonar_backend.settings'
sonar-django-backend      | Starting development server at http://0.0.0.0:9080/
sonar-django-backend      | Quit the server with CONTROL-C.
celery-workers            | [2024-11-04 10:01:24,559: DEBUG/MainProcess] | Worker: Preparing bootsteps.
celery-workers            | [2024-11-04 10:01:24,562: DEBUG/MainProcess] | Worker: Building graph...
celery-workers            | [2024-11-04 10:01:24,562: DEBUG/MainProcess] | Worker: New boot order: {Timer, Hub, Pool, Autoscaler, StateDB, Beat, Consumer}
celery-workers            | [2024-11-04 10:01:24,573: DEBUG/MainProcess] | Consumer: Preparing bootsteps.
celery-workers            | [2024-11-04 10:01:24,573: DEBUG/MainProcess] | Consumer: Building graph...

```
