### PR TITLE
Fix path: in github actions so they actually run

### DIFF
--- a/.github/workflows/backend-cli.yml
+++ b/.github/workflows/backend-cli.yml
@@ -2,8 +2,8 @@ name: test cli with backend
 on:
   pull_request:
     paths:
-      - './apps/backend/**'
-      - './apps/cli/**'
+      - 'apps/backend/**'
+      - 'apps/cli/**'
   workflow_dispatch:
 jobs:
   test:

--- a/.github/workflows/backend-coverage.yml
+++ b/.github/workflows/backend-coverage.yml
@@ -2,7 +2,7 @@ name: backend coverage report
 on:
   pull_request:
     paths:
-      - './apps/backend/**'
+      - 'apps/backend/**'
   workflow_dispatch:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -2,7 +2,7 @@ name: backend test
 on:
   pull_request:
     paths:
-      - './apps/backend/**'
+      - 'apps/backend/**'
   workflow_dispatch:
 permissions: write-all
 concurrency:

--- a/.github/workflows/cli-test.yml
+++ b/.github/workflows/cli-test.yml
@@ -2,7 +2,7 @@ name: cli lint
 on:
   pull_request:
     paths:
-      - './apps/cli/**'
+      - 'apps/cli/**'
   workflow_dispatch:
 jobs:
   lint:

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -2,7 +2,7 @@ name: frontend test build
 on:
   pull_request:
     paths:
-      - './apps/frontend/**'
+      - 'apps/frontend/**'
   workflow_dispatch:
 jobs:
   frontend-test:


### PR DESCRIPTION
Most github actions had an incorrect `path:` directive, which is why they haven't been running.

The path directive was used to try to only run actions that would actually be impacted by the changes in a PR. It should work properly now.