### PR TITLE
Rename covsonar to sonar in the frontend

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CovSonar</title>
+    <title>Sonar</title>
   </head>
   <body>
     <div id="app"></div>

--- a/apps/frontend/src/App.vue
+++ b/apps/frontend/src/App.vue
@@ -6,7 +6,7 @@
         <div class="flex  flex-wrap justify-content-between">
           <div class="flex align-items-center justify-content-center">
             <div style="font-size: 2rem; color: var(--text-color);">
-              <i class="pi pi-spinner" style="font-size: 3rem; color: var(--text-color);"></i>ovSonar
+              Sonar
             </div>
           </div>
           <div class="flex align-items-center justify-content-center">

--- a/apps/frontend/src/views/AboutView.vue
+++ b/apps/frontend/src/views/AboutView.vue
@@ -5,12 +5,12 @@
       class="shadow-4 align-center animation-duration-1000 animation-ease-in-out mb-4">
       <Card>
         <template #title>
-          <h3 class="text-primary mt-4">About covSonar Explorer</h3>
+          <h3 class="text-primary mt-4">About Sonar</h3>
         </template>
         <template #content>
           <p class="m-1">
-            At <strong>covSonar Explorer</strong>, we provide an application to explore and compare metadata from
-            COVID-19 sequences available from our data source.
+            <strong>Sonar</strong> is an application to explore and compare metadata from
+            SARS-CoV-2 sequences available from our data source.
             Furthermore, we offer an advanced filtering tool that enables more detailed queries. This tool benefits all
             users by facilitating better analysis and research.
           </p>


### PR DESCRIPTION
This is a tiny PR since the frontend wasn't using the word covsonar very much. Neverthess it's very visible to users and might cause some confusion for those who knew the old covsonar project and don't understand that this is a different/new project.