### PR TITLE
Fix wrapping of genomic and proteomic profiles

### DIFF
--- a/apps/frontend/src/components/GenomicProfileLabel.vue
+++ b/apps/frontend/src/components/GenomicProfileLabel.vue
@@ -1,7 +1,7 @@
 <template>
     <span v-tooltip.bottom="tooltip">
         <span :style="{ color: variantColor }">{{ variantString }}</span>
-        <span v-if="!isLast">,&nbsp;</span>
+        <span v-if="!isLast">, </span>
     </span>
 </template>
 


### PR DESCRIPTION
Just needed to change a `&nbsp;` (= non-breaking space) into a normal space, which allows the text to break the line there.