### PR TITLE
Make it more clear which metadata columns match which properties

### DIFF
--- a/apps/cli/src/sonar_cli/utils.py
+++ b/apps/cli/src/sonar_cli/utils.py
@@ -674,13 +674,15 @@ class sonarUtils:
                         f"Property '{prop}' is unknown. Use 'list-prop' to see all valid properties or 'add-prop' to add it before import."
                     )
 
-        LOGGER.info("Displaying column-to-property mappings:")
+        LOGGER.info("Displaying property mappings:")
+        LOGGER.info("(Input table column name -> Sonar database property name)")
+
         for prop, prop_info in propnames.items():
             if prop == "sample":
-                LOGGER.verbose(f"{prop} <- {prop_info}")
+                LOGGER.info(f"{prop_info} -> {prop}")
                 continue
             db_property_name = prop_info.get("db_property_name", "N/A")
-            LOGGER.verbose(f"{prop} <- {db_property_name}")
+            LOGGER.info(f"{prop} -> {db_property_name}")
         LOGGER.info("--------")
 
         return propnames


### PR DESCRIPTION
When importing metadata using the sonar-cli, make it a bit more clear which name belongs to the input table column, and which is the sonar property name.
```
Reading property names from user-provided '--cols'
Displaying property mappings:
(Input table column name -> Sonar database property name)
ID -> sample
DATE_OF_SAMPLING -> collection_date
--------
```
This is probably a bit overly verbose but we can address that some day in the future.