### PR TITLE
Add config option KEEP_IMPORTED_DATA_FILES to allow us to delete files as their data is imported into the backend

### DIFF
--- a/apps/backend/compose.yml
+++ b/apps/backend/compose.yml
@@ -49,6 +49,7 @@ services:
       - SONAR_DATA_PROCESSING_FOLDER=$SONAR_DATA_PROCESSING_FOLDER
       - SONAR_DATA_ARCHIVE=$SONAR_DATA_ARCHIVE
       - SECRET_KEY=$SECRET_KEY
+      - KEEP_IMPORTED_DATA_FILES=$KEEP_IMPORTED_DATA_FILES
     restart: no
     entrypoint: /bin/sh -c
     command: ["python manage.py migrate"]
@@ -86,6 +87,7 @@ services:
       - SONAR_DATA_PROCESSING_FOLDER=$SONAR_DATA_PROCESSING_FOLDER
       - SONAR_DATA_ARCHIVE=$SONAR_DATA_ARCHIVE
       - SECRET_KEY=$SECRET_KEY
+      - KEEP_IMPORTED_DATA_FILES=$KEEP_IMPORTED_DATA_FILES
     restart: unless-stopped
     entrypoint: /bin/sh -c
     command: ["${START_DJANGO_SERVER}"]
@@ -132,6 +134,7 @@ services:
       - SONAR_DATA_PROCESSING_FOLDER=$SONAR_DATA_PROCESSING_FOLDER
       - SONAR_DATA_ARCHIVE=$SONAR_DATA_ARCHIVE
       - SECRET_KEY=$SECRET_KEY
+      - KEEP_IMPORTED_DATA_FILES=$KEEP_IMPORTED_DATA_FILES
     restart: on-failure
     entrypoint: /bin/sh -c
     command: ["python manage.py runapscheduler"]
@@ -199,6 +202,7 @@ services:
       - SONAR_DATA_PROCESSING_FOLDER=$SONAR_DATA_PROCESSING_FOLDER
       - SONAR_DATA_ARCHIVE=$SONAR_DATA_ARCHIVE
       - SECRET_KEY=$SECRET_KEY
+      - KEEP_IMPORTED_DATA_FILES=$KEEP_IMPORTED_DATA_FILES
     depends_on:
       sonar-cache:
         condition: service_started
@@ -230,6 +234,7 @@ services:
       - SONAR_DATA_PROCESSING_FOLDER=$SONAR_DATA_PROCESSING_FOLDER
       - SONAR_DATA_ARCHIVE=$SONAR_DATA_ARCHIVE
       - SECRET_KEY=$SECRET_KEY
+      - KEEP_IMPORTED_DATA_FILES=$KEEP_IMPORTED_DATA_FILES
     depends_on:
       celery-workers:
         condition: service_started

--- a/apps/backend/conf/docker/common.env
+++ b/apps/backend/conf/docker/common.env
@@ -8,6 +8,10 @@ SONAR_DATA_FOLDER="/sonar/data"
 SONAR_DATA_ENTRY_FOLDER="/sonar/data/import"
 SONAR_DATA_PROCESSING_FOLDER="/sonar/data/processing"
 SONAR_DATA_ARCHIVE="/sonar/data/archive"
+# Have the backend delete data files sent from the cli as they are imported
+# into the database. These would usually go in the SONAR_DATA_ARCHIVE/completed
+# directory.
+KEEP_IMPORTED_DATA_FILES=false
 LOG_PATH="/logs"
 
 # Path to directories outside the sonar container

--- a/apps/backend/conf/docker/dev.env
+++ b/apps/backend/conf/docker/dev.env
@@ -7,6 +7,7 @@ PROPERTY_BATCH_SIZE=10000
 START_DJANGO_SERVER="python manage.py collectstatic --noinput && python manage.py runserver 0.0.0.0:9080"
 # This is just the file name of a file inside ./conf/postgresql
 POSTGRES_CONFIG_FILE=dev.conf
+KEEP_IMPORTED_DATA_FILES=true
 
 # Profiling:
 # Enable this and "django_extensions" in settings.dev to enable per request

--- a/apps/backend/covsonar_backend/settings.py
+++ b/apps/backend/covsonar_backend/settings.py
@@ -37,6 +37,7 @@ env = environ.Env(
     SAMPLE_BATCH_SIZE=(int, 10),
     PROPERTY_BATCH_SIZE=(int, 1000),
     PROFILE_IMPORT=(bool, False),
+    KEEP_IMPORTED_DATA_FILES=(bool, False),
 )
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -267,6 +268,11 @@ CACHES = {
         },
     }
 }
+
+# If true, keep the data files that were sent from the CLI in an archive
+# folder, even after that data has been imported into the database.
+# Defaults to false, so the files are immediately deleted to save space.
+KEEP_IMPORTED_DATA_FILES = env("KEEP_IMPORTED_DATA_FILES")
 
 # Celery settings
 CELERY_BROKER_URL = f"{env('REDIS_URL')}0"

--- a/apps/cli/src/sonar_cli/utils.py
+++ b/apps/cli/src/sonar_cli/utils.py
@@ -429,6 +429,7 @@ class sonarUtils:
 
     @staticmethod
     def zip_import_upload_sample_singlethread(shared_objects: dict, sample_list):
+        """Bundle up the data to be sent to the backend and send it"""
 
         files_to_compress = []
         for kwargs in sample_list:


### PR DESCRIPTION
I tested that this worked but didn't do a huge import to make sure it really limits the maximum required disk space. I'll do that over the holidays but I think we can merge it as is anyway, it's a step in the right direction.
