### PR TITLE
Expand possible tilde in config path for snpEff

### DIFF
--- a/apps/cli/src/sonar_cli/annotation.py
+++ b/apps/cli/src/sonar_cli/annotation.py
@@ -1,7 +1,7 @@
 import os
+from pathlib import Path
 import subprocess
 from typing import Optional
-from pathlib import Path
 
 from sonar_cli.cache import sonarCache
 from sonar_cli.logging import LoggingConfigurator
@@ -37,7 +37,9 @@ class Annotator:
         ]
 
         if self.config_path:
-            command.extend(["-nodownload", "-config", Path(f"{self.config_path}").expanduser()])
+            command.extend(
+                ["-nodownload", "-config", Path(f"{self.config_path}").expanduser()]
+            )
 
         try:
             # Run the SnpEff annotation


### PR DESCRIPTION
A tilde in the configuration file path was causing the snpEff call to crash. This should fix it.