### PR TITLE
Update sample selection by pressing enter in profile box. Also fix resizing of update buttons when they have a red border

### DIFF
--- a/apps/frontend/src/components/FilterBar.vue
+++ b/apps/frontend/src/components/FilterBar.vue
@@ -58,8 +58,8 @@
             v-model="profileFilter.value"
             style="flex: auto"
             :placeholder="'S:L452R, S:del:143-144, del:21114-21929, T23018G'"
-            v-on:keyup.enter="updateSamplesInTableAndFilteredStatistics()"
             class="mr-1"
+            @keyup.enter="updateSamplesInTableAndFilteredStatistics()"
           />
           <PrimeButton
             v-if="profileFilter.value"


### PR DESCRIPTION
The only box where I really want to be able to press Enter to update the selection is the profile text box, so I just added code to react to the enter event there. The other small tweak was to handle the button resizing that happens when the Update sample selection button gets its red border. This extra 4px border was causing an annoying resizing of the box. To fix it I just added a transparent 4px border to the default state of the button.
