### PR TITLE
Add missing > to vcf header, also add line for config (= the reference, for now)

### DIFF
--- a/apps/cli/src/sonar_cli/utils.py
+++ b/apps/cli/src/sonar_cli/utils.py
@@ -1285,7 +1285,8 @@ def _write_vcf_header(handle, reference: str, all_samples: List[str]):
     handle.write("##fileformat=VCFv4.2\n")
     handle.write("##poweredby=sonar-cli\n")
     handle.write(f"##reference={reference}\n")
-    handle.write('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype"\n')
+    handle.write('##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n')
+    handle.write(f"##contig=<ID={reference}>\n")
     handle.write(
         "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t"
         + "\t".join(all_samples)


### PR DESCRIPTION
I think this only resolves some warnings from bcftools when merging vcfs for snpEff annotation. The real bug that is causing the crash is probably elsewhere, but it's nice to tidy up the output a bit.
