### PR TITLE
pre-commit: block if trying to add a file larger than 5MB

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,8 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
+      - id: check-added-large-files
+        args: ['--maxkb=5120']
       - id: check-yaml
       - id: end-of-file-fixer
         types_or: [python, markdown, shell, vue, ts]


### PR DESCRIPTION
As a safety measure, we use pre-commit to block commits of files larger than 5MB. This can be worked around if you really want to, but in most cases it is either a bad idea or a mistake.
