### PR TITLE
Check for empty vcf before filtering to avoid bcftools crash. Always pass back sample(s) from _get_vcf_data_form_var_file.

### DIFF
--- a/apps/cli/src/sonar_cli/align.py
+++ b/apps/cli/src/sonar_cli/align.py
@@ -69,8 +69,6 @@ class sonarAligner:
         # self.log("data:" + str(data))
         # alignment = self.align(data["seq_file"], data["ref_file"])
         alignment = align_MAFFT(data["mafft_seqfile"])
-        # LOGGER.debug(alignment[0][0:20]) qry
-        # priLOGGER.debugnt(alignment[1][0:20]) ref
 
         # NOTE: this line was already performant
         nuc_vars = [x for x in self.extract_vars(*alignment, elem_acc=source_acc)]

--- a/apps/cli/src/sonar_cli/utils.py
+++ b/apps/cli/src/sonar_cli/utils.py
@@ -1187,10 +1187,10 @@ def _get_vcf_data_form_var_file(cursor: dict, selected_ref_seq, showNX) -> Dict:
     records = collections.defaultdict(
         lambda: collections.defaultdict(lambda: collections.defaultdict(dict))
     )
-    all_samples = set()
 
     rows = read_var_file(cursor["var_file"], exclude_var_type="cds", showNX=showNX)
     sample_name = cursor["name"]
+    all_samples = set(sample_name.split("\t"))
 
     for row in rows:
         try:
@@ -1203,28 +1203,22 @@ def _get_vcf_data_form_var_file(cursor: dict, selected_ref_seq, showNX) -> Dict:
             raise
 
         # Split out the data from each row
-        chrom, pos, pre_ref, ref, alt, samples = (
+        chrom, pos, pre_ref, ref, alt = (
             row["variant.reference"],
             row["variant.start"],
             pre_ref,
             row["variant.ref"],
             row["variant.alt"],
-            sample_name,
         )
 
-        # Convert the samples string into a set
-        sample_set = set(samples.split("\t"))
         # POS position in VCF format: 1-based position
         pos = pos + 1
         # Skip the empty alternate values
 
-        records[chrom][pos][ref][alt] = sample_set
+        records[chrom][pos][ref][alt] = all_samples
 
         if "pre_ref" not in records[chrom][pos]:
             records[chrom][pos]["pre_ref"] = pre_ref
-
-        # Update the list of all unique samples
-        all_samples.update(sample_set)
 
     return records, sorted(all_samples)
 


### PR DESCRIPTION
Fix bug where importing a sequence that is identical to the reference causes the cli to crash during import.
