### PR TITLE
Abort the process if we cannot get genbank file

### DIFF
--- a/apps/cli/src/sonar_cli/cache.py
+++ b/apps/cli/src/sonar_cli/cache.py
@@ -135,7 +135,9 @@ class sonarCache:
         self.include_nx = include_nx
         self.isBuilt_snpEffcache = self.build_snpeff_cache(reference=self.refacc)
         if not self.isBuilt_snpEffcache:
-            LOGGER.error("Could not retrieve the snpEff reference annotation from the sonar server. Aborting.")
+            LOGGER.error(
+                "Could not retrieve the snpEff reference annotation from the sonar server. Aborting."
+            )
             sys.exit(1)
 
     def __enter__(self):


### PR DESCRIPTION
## Description
Address #313

## Changes
1. Add an if block to check if we can retrieve genbank file.

## Output

```
Current version sonar-cli:1.0.0
Alignment Tool: MAFFT
Skip N/X mutation: False
Import mode: add/update existing samples in the database and cache directory.
The reference MN908947.3 is used.

ERROR Cannot get genbank file for reference MN908947.3

ERROR Aborting the process.
```