### PR TITLE
snpEff reference retrieved and built even when no sequences are being imported

### DIFF
--- a/apps/cli/src/sonar_cli/cache.py
+++ b/apps/cli/src/sonar_cli/cache.py
@@ -48,6 +48,7 @@ class sonarCache:
         debug: bool = False,
         disable_progress: bool = False,
         include_nx: bool = True,
+        auto_anno: bool = False,
     ):
         """
         Initialize the sonarCache object.
@@ -133,12 +134,15 @@ class sonarCache:
                 open(self.error_logfile_name, "a+") if logfile else None
             )
         self.include_nx = include_nx
-        self.isBuilt_snpEffcache = self.build_snpeff_cache(reference=self.refacc)
-        if not self.isBuilt_snpEffcache:
-            LOGGER.error(
-                "Could not retrieve the snpEff reference annotation from the sonar server. Aborting."
-            )
-            sys.exit(1)
+        self.auto_anno = auto_anno
+        if self.auto_anno:
+            self.isBuilt_snpEffcache = self.build_snpeff_cache(reference=self.refacc)
+
+            if not self.isBuilt_snpEffcache:
+                LOGGER.error(
+                    "Could not retrieve the snpEff reference annotation from the sonar server. Aborting."
+                )
+                sys.exit(1)
 
     def __enter__(self):
         return self

--- a/apps/cli/src/sonar_cli/sonar.py
+++ b/apps/cli/src/sonar_cli/sonar.py
@@ -729,6 +729,7 @@ def handle_import(args: argparse.Namespace):
         LOGGER.warn("Invalid --method. Please use 'import -h' to see available methods")
         exit(1)
     LOGGER.info(f"Skip N/X mutation: {args.skip_nx}")
+    LOGGER.info(f"Variant Annotation: {args.auto_anno}")
     sonarUtils.import_data(
         db=args.db,
         fasta=args.fasta,

--- a/apps/cli/src/sonar_cli/utils.py
+++ b/apps/cli/src/sonar_cli/utils.py
@@ -151,6 +151,7 @@ class sonarUtils:
             update=update,
             progress=progress,
             include_nx=include_nx,
+            auto_anno=auto_anno,
         )
 
         # importing sequences
@@ -162,7 +163,6 @@ class sonarUtils:
                 threads,
                 progress,
                 method,
-                auto_anno,
                 no_upload_sample,
             )
 
@@ -205,6 +205,7 @@ class sonarUtils:
         progress: bool = False,
         debug: bool = False,
         include_nx: bool = True,
+        auto_anno: bool = False,
     ) -> sonarCache:
         """Set up a cache for sequence data."""
         # Instantiate a sonarCache object.
@@ -218,6 +219,7 @@ class sonarUtils:
             disable_progress=not progress,
             refacc=reference,
             include_nx=include_nx,
+            auto_anno=auto_anno,
         )
 
     @staticmethod
@@ -228,7 +230,6 @@ class sonarUtils:
         threads: int = 1,
         progress: bool = False,
         method: int = 1,
-        auto_anno: bool = False,
         no_upload_sample: bool = False,
     ) -> None:
         """
@@ -317,7 +318,7 @@ class sonarUtils:
             )
             for i in range(0, len(passed_samples_list), n)
         ]
-        if auto_anno:
+        if cache.auto_anno:
             anno_result_list = []
             start_anno_time = get_current_time()
             try:
@@ -395,7 +396,7 @@ class sonarUtils:
                     sleep_time = 3
                     time.sleep(sleep_time)
 
-            if auto_anno:
+            if cache.auto_anno:
 
                 for chunk_number, each_file in enumerate(
                     tqdm(


### PR DESCRIPTION
## Description
Address #333

## Changes
1. Unify the `auto_anno` variable by moving it to the Cache class. 
2. Add a check condition in the Cache __init__.

## Output

Enable variant annotation. 
```
Current version sonar-cli:1.0.0
Alignment Tool: MAFFT
Skip N/X mutation: False
Variant Annotation: True
Import mode: add/update existing samples in the database and cache directory.
The reference MN908947.3 is used.
Genbank downloaded successfully: /mnt/c/works/covid-size-test/1new_3000_mafft/snpeff_data/MN908947.3/genes.gbk
Building snpeff cache for reference MN908947.3
Picked up _JAVA_OPTIONS: -Xms128m -Xmx4g
        Protein check:  MN908947.3      OK: 12  Not found: 0    Errors: 0       Error percentage: 0.0%
processing 3000.covid19.fasta... 100% [89.6M/89.6M, 00:02<00:00, 42.9Mbytes/s]
[runtime] Sequence check: 0:00:15
```

Disable variant annotation.
```
Current version sonar-cli:1.0.0
Alignment Tool: MAFFT
Skip N/X mutation: False
Variant Annotation: False
Import mode: add/update existing samples in the database and cache directory.
The reference MN908947.3 is used.
processing 3000.covid19.fasta... 100% [89.6M/89.6M, 00:02<00:00, 42.5Mbytes/s]
[runtime] Sequence check: 0:00:15

Total input samples: 3000
Total samples that need to be processed: 3000
```

## Note
1. Once it builds, it is already there; no rebuild function is currently available. If you wish to rebuild it, manually delete the snpeff directory, and run the command with annotation, it will rebuild again. 