### PR TITLE
sonar-cli validate metadata files before sending them to the backend

### DIFF
--- a/apps/cli/tests/test_e2e_import.py
+++ b/apps/cli/tests/test_e2e_import.py
@@ -61,7 +61,7 @@ def test_add_sequence_mafft_anno_prop(monkeypatch, api_url, tmpfile_name):
     #         func(** arg) for arg in args
     #     ),
     # )
-    command = f"import --db {api_url} -r MN908947.3 --method 1 --fasta covid19/seqs.fasta.gz --cache {tmpfile_name}/mafft -t 2 --tsv covid19/meta.tsv --cols name=IMS_ID collection_date=DATE_DRAW sequencing_tech=SEQ_REASON sample_type=SAMPLE_TYPE "
+    command = f"import --db {api_url} -r MN908947.3 --method 1 --fasta covid19/seqs.fasta.gz --cache {tmpfile_name}/mafft -t 2 --auto-anno --tsv covid19/meta.tsv --cols name=IMS_ID collection_date=DATE_DRAW sequencing_tech=SEQ_REASON sample_type=SAMPLE_TYPE "
     code = run_cli(command)
 
     assert code == 0


### PR DESCRIPTION
## Description
address #335 
## Changes
1. Remove unused variable.
2. Add a check step to verify the columns existing in the provided CSV/TSV.
3. Send CSV/TSV files containing only valid columns (CLI does not send the entire file).

## Outputs

Report missing a column and specify which file is involved.
```bash
WARNING Property 'sample_type' is unknown. Use 'list-prop' to see all valid properties or 'add-prop' to add it before import.

WARNING Property 'sequencing_reason' is unknown. Use 'list-prop' to see all valid properties or 'add-prop' to add it before import.

WARNING Column 'country' does not exist in the provided files: covid19.1000.tsv, covid19.13000.tsv.

WARNING Column 'genome_completeness' does not exist in the provided files: covid19.1000.tsv, covid19.13000.tsv.

WARNING Column 'no_column' does not exist in the provided files: covid19.1000.tsv
```

If the ID columns in the name key do not exist, the CLI will stop the import process.
```bash
WARNING Property 'sample_type' is unknown. Use 'list-prop' to see all valid properties or 'add-prop' to add it before import.

WARNING Property 'sequencing_reason' is unknown. Use 'list-prop' to see all valid properties or 'add-prop' to add it before 

ERROR ID column 'NO_NAME' does not exist in the provided files: covid19.1000.tsv

```

## Note:

1. In the current implementation, we select only the shared columns among the files (for example, File 1 = ColA, ColB, ColC; File 2 = ColB, ColC; File 3 = ColB), so we only send ColB to the server. In the best-case scenario right now, we assume there is one metadata file that contains all samples or multiple files with similar columns 