### PR TITLE
optimize get_meta_data_coverage calculations

### DIFF
--- a/apps/frontend/src/stores/samples.ts
+++ b/apps/frontend/src/stores/samples.ts
@@ -176,7 +176,7 @@ export const useSamplesStore = defineStore('samples', {
         samples_total: 0,
         first_sample_date: '',
         latest_sample_date: '',
-        meta_data_coverage: {},
+        populated_metadata_fields: [],
       }
       try {
         const statistics = await API.getInstance().getSampleStatistics()
@@ -313,7 +313,7 @@ export const useSamplesStore = defineStore('samples', {
           console.error('API request failed')
           return
         }
-        const metaData = this.statistics?.meta_data_coverage ?? {}
+        const metaData = this.statistics?.populated_metadata_fields ?? []
         this.propertiesDict = {}
         res.values.forEach(
           (property: { name: string; query_type: string; description: string }) => {
@@ -329,7 +329,7 @@ export const useSamplesStore = defineStore('samples', {
         // keep only those properties that have a coverage, i.e. that are not entirly empty
         // & drop the 'name' column because the ID column is fixed
         this.propertyTableOptions = Object.keys(this.propertiesDict).filter(
-          (key) => key !== 'name' && metaData[key] == true,
+          (key) => key !== 'name' && metaData.includes(key),
         )
         this.propertyMenuOptions = [
           'name',

--- a/apps/frontend/src/util/types.ts
+++ b/apps/frontend/src/util/types.ts
@@ -122,7 +122,7 @@ export type Statistics = {
   samples_total: number
   first_sample_date: string
   latest_sample_date: string
-  meta_data_coverage: { [key: string]: boolean }
+  populated_metadata_fields: string[]
 }
 
 export type FilteredStatistics = {


### PR DESCRIPTION
- optimize `get_meta_data_coverage` function in `get_statistics` endpoint
- --> by creating a separate function `get_meta_data_coverage_boolean` that returns only True/False instead of counts
- `get_meta_data_coverage` with counts is still used for `filtered_statistics_plots`

- still needs to be benchmarked

![image](https://github.com/user-attachments/assets/eb603dad-1ecf-497d-84fd-ff8092606112)
