### PR TITLE
Rename frontend from "sonar-frontend-new" to "sonar-frontend"

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "sonar-frontend-new",
+  "name": "sonar-frontend",
   "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "sonar-frontend-new",
+      "name": "sonar-frontend",
       "version": "1.0.1",
       "dependencies": {
         "axios": "^1.13.5",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sonar-frontend-new",
+  "name": "sonar-frontend",
   "version": "1.0.1",
   "private": true,
   "type": "module",


### PR DESCRIPTION
This is a tiny change to fix the package.json and associated lock file.
