### PR TITLE
Fix for Testing equality to None

### DIFF
--- a/apps/backend/rest_api/test/mixins.py
+++ b/apps/backend/rest_api/test/mixins.py
@@ -176,7 +176,7 @@ class UpdateViewSetTestMixin(RetrieveViewSetTestMixin):
             self.fail(f"File {filename} needs filters and data to test update.")
         filters = test_content["params"]["filters"]
         data = test_content["params"]["data"]
-        if pk == None:
+        if pk is None:
             if "pk" in filters:
                 pk = filters["pk"]
             elif "id" in filters:


### PR DESCRIPTION
Use identity comparison for `None` checks.

Best fix (without changing functionality): in `apps/backend/rest_api/test/mixins.py`, replace the `pk == None` check in `_test_update_error_examples` with `pk is None`. This preserves behavior for normal values while preventing any surprising behavior from overloaded equality and satisfies CodeQL.

No new imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._