### PR TITLE
Fix for Testing equality to None

### DIFF
--- a/apps/backend/rest_api/test/mixins.py
+++ b/apps/backend/rest_api/test/mixins.py
@@ -144,7 +144,7 @@ class UpdateViewSetTestMixin(RetrieveViewSetTestMixin):
             self.fail(f"File {filename} needs filters and data to test update.")
         filters = params.get("filters")
         data = params.get("data")
-        if pk == None:
+        if pk is None:
             if "pk" in filters:
                 pk = filters["pk"]
             elif "id" in filters:


### PR DESCRIPTION
Use identity comparison for `None` checks.

Best fix: in `apps/backend/rest_api/test/mixins.py`, within `UpdateViewSetTestMixin._test_update`, replace `if pk == None:` with `if pk is None:`. This preserves functionality while making the check correct, idiomatic, and robust against custom equality implementations. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._