### PR TITLE
Change the cli to subject-first, update documentation and scripts/tests

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -104,7 +104,7 @@ sonar-cli -v
 Next make sure you can contact the backend:
 
 ```sh
-$ sonar-cli list-ref
+$ sonar-cli reference list
 Current version sonar-cli:1.0.3
 ╒══════╤═════════════╤═══════════════╤═════════════════════════════════════════════════╕
 │   id │ accession   │ taxon         │ organism                                        │
@@ -129,16 +129,22 @@ Then you can run it, passing in whatever parameters you want:
 ```
 $ ./scripts/linux/sonar-cli-docker.sh --help
 usage: sonar-cli [-h] [-v]
-                 {list-ref,add-prop,delete-prop,add-ref,delete-ref,import,delete-sample,list-prop,import-lineage,match,tasks}
+                 {reference,property,sample,sequence,dataset,lineage,task,info}
                  ...
 
 sonar-cli 1.0.3: Sonar command line tool to interface with the sonar-backend
 and PostgreSQL version.
 
 positional arguments:
-  {list-ref,add-prop,delete-prop,add-ref,delete-ref,import,delete-sample,list-prop,import-lineage,match,tasks}
-    list-ref            Lists all available references in the database
-    add-prop            add a property to the database
+  {reference,property,sample,sequence,dataset,lineage,task,info}
+    reference           Manage reference genomes in the database.
+    property            Manage queryable properties in the database.
+    sample              Import, match, and delete samples.
+    sequence            Delete sequences from the database.
+    dataset             Download and import public datasets.
+    lineage             Import lineage parent-child relationships.
+    task                Query background job status.
+    info                Display database information and statistics.
 [...]
 ```
 
@@ -147,7 +153,7 @@ The published image is `ghcr.io/rki-mf1/sonar-cli`. For example:
 ```sh
 docker run --rm \
   --env API_URL=http://127.0.0.1:8000/api \
-  ghcr.io/rki-mf1/sonar-cli:latest list-ref
+  ghcr.io/rki-mf1/sonar-cli:latest reference list
 ```
 
 Use `http://127.0.0.1:8000/api` when talking to the local development stack
@@ -161,7 +167,7 @@ container:
 docker run --rm \
   --env API_URL=http://127.0.0.1:8000/api \
   -v "$PWD/test-data:/data" \
-  ghcr.io/rki-mf1/sonar-cli:latest import -r MN908947.3 --fasta /data/SARS-CoV-2_1000.fasta.xz
+  ghcr.io/rki-mf1/sonar-cli:latest sample import -r MN908947.3 --fasta /data/SARS-CoV-2_1000.fasta.xz
 ```
 
 ### Test Datasets
@@ -180,32 +186,32 @@ The table below shows the several commands that can be used.
 
 | Subcommand                        | Purpose                                                            |
 | --------------------------------- | ------------------------------------------------------------------ |
-| [import](#importing-genomes)      | Import genome sequences and sample information into the database.  |
-| [match](#matching-genomes)        | Match genome sequences and sample information within the database. |
-| [add-ref](#adding-reference)      | Add reference genome sequences to the database.                    |
-| [delete-ref](#delete-reference)   | Delete reference genome sequences from the database.               |
-| [list-ref](#listing-reference)    | List available reference genome sequences in the database.         |
-| [list-prop](#listing-property)    | List queryable properties in the database.                         |
-| [add-prop](#adding-property)      | Add property key for storage and querying in the database.         |
-| [delete-prop](#deleting-property) | Delete properties in the database.                                 |
-| [delete-sample](#deleting-sample) | Delete samples and associated information from the database.       |
-| [import-lineage](#import-lineage) | Import lineage parent-child relationships (e.g. SARS-CoV-2 Pangolin lineages). |
-| [tasks](#tasks)                   | Query background job status.                                       |
+| [sample import](#importing-genomes) | Import genome sequences and sample information into the database. |
+| [sample match](#matching-genomes) | Match genome sequences and sample information within the database. |
+| [reference add](#adding-reference)      | Add reference genome sequences to the database.                    |
+| [reference delete](#delete-reference)   | Delete reference genome sequences from the database.               |
+| [reference list](#listing-reference)    | List available reference genome sequences in the database.         |
+| [property list](#listing-property)    | List queryable properties in the database.                         |
+| [property add](#adding-property)      | Add property key for storage and querying in the database.         |
+| [property delete](#deleting-property) | Delete properties in the database.                                 |
+| [sample delete](#deleting-sample) | Delete samples and associated information from the database.       |
+| [lineage import](#import-lineage) | Import lineage parent-child relationships (e.g. SARS-CoV-2 Pangolin lineages). |
+| [task list](#tasks)               | Query background job status.                                       |
 
 > [!TIP]
 > You can use `--db` to provide the URL to the backend (and it overwrites the configuration).
 >
-> for example, `sonar-cli add-ref --db "http://127.0.0.1:8000/api" --gb test-data/sars-cov-2/MN908947.nextclade.gb`
+> for example, `sonar-cli reference add --db "http://127.0.0.1:8000/api" --gb test-data/sars-cov-2/MN908947.nextclade.gb`
 >
 > for the `example-deploy` bundle, the corresponding default would be
-> `sonar-cli add-ref --db "http://127.0.0.1:18000/api" --gb test-data/sars-cov-2/MN908947.nextclade.gb`
+> `sonar-cli reference add --db "http://127.0.0.1:18000/api" --gb test-data/sars-cov-2/MN908947.nextclade.gb`
 
 ## Adding Reference
 
-The `add-ref` subcommand is used to add reference genome sequences to the database.
+The `reference add` subcommand is used to add reference genome sequences to the database.
 
 ```sh
-sonar-cli add-ref --gb test-data/sars-cov-2/MN908947.nextclade.gb
+sonar-cli reference add --gb test-data/sars-cov-2/MN908947.nextclade.gb
 ```
 
 ## Importing Genomes
@@ -215,25 +221,25 @@ The `import` subcommand is used to import genome sequences and sample informatio
 Basic command:
 
 ```sh
-sonar-cli import -r MN908947.3 --fasta test-data/sars-cov-2/SARS-CoV-2_1000.fasta.xz --cache cache_folder/ -t 2 --method mafft
+sonar-cli sample import -r MN908947.3 --fasta test-data/sars-cov-2/SARS-CoV-2_1000.fasta.xz --cache cache_folder/ -t 2 --method mafft
 ```
 
 Example command: Including properties during import
 
 ```sh
-sonar-cli import -r MN908947.3 --fasta test-data/sars-cov-2/SARS-CoV-2_1000.fasta.xz --tsv test-data/sars-cov-2/SARS-CoV-2_1000.tsv.xz --cache cache_folder/ -t 2 --method mafft  --cols name=ID sequencing_tech=SEQUENCING_METHOD zip_code=DL.POSTAL_CODE  collection_date=DATE_OF_SAMPLING lab=SL.ID sample_type=SEQUENCE.SAMPLE_TYPE sequencing_reason=SEQUENCE.SEQUENCING_REASON  lineage=LINEAGE_LATEST
+sonar-cli sample import -r MN908947.3 --fasta test-data/sars-cov-2/SARS-CoV-2_1000.fasta.xz --tsv test-data/sars-cov-2/SARS-CoV-2_1000.tsv.xz --cache cache_folder/ -t 2 --method mafft  --cols name=ID sequencing_tech=SEQUENCING_METHOD zip_code=DL.POSTAL_CODE  collection_date=DATE_OF_SAMPLING lab=SL.ID sample_type=SEQUENCE.SAMPLE_TYPE sequencing_reason=SEQUENCE.SEQUENCING_REASON  lineage=LINEAGE_LATEST
 ```
 
 Example command: Including annotation step(`--auto-anno`)
 
 ```sh
-sonar-cli import -r MN908947.3 --fasta test-data/sars-cov-2/SARS-CoV-2_2.fasta.gz --tsv test-data/sars-cov-2/SARS-CoV-2_1000.tsv.xz --cache cache_folder/ -t 2 --method mafft  --cols name=ID  --auto-anno --auto-link
+sonar-cli sample import -r MN908947.3 --fasta test-data/sars-cov-2/SARS-CoV-2_2.fasta.gz --tsv test-data/sars-cov-2/SARS-CoV-2_1000.tsv.xz --cache cache_folder/ -t 2 --method mafft  --cols name=ID  --auto-anno --auto-link
 ```
 
 To view all available options:
 
 ```sh
-sonar-cli import -h
+sonar-cli sample import -h
 ```
 
 ## Matching Genomes
@@ -243,69 +249,69 @@ The `match` subcommand is used to match genome sequences and sample information 
 List all mutations
 
 ```sh
-sonar-cli match -r MN908947.3
+sonar-cli sample match -r MN908947.3
 ```
 
 With specific mutations (NT and AA) and count
 
 ```sh
-sonar-cli match -r MN908947.3 --profile C26270T S:G339D --count
+sonar-cli sample match -r MN908947.3 --profile C26270T S:G339D --count
 ```
 
 with mutations and property
 
 ```sh
-sonar-cli match -r MN908947.3 --profile C26270T S:G339D --sequencing_tech ILLUMINA --format csv
+sonar-cli sample match -r MN908947.3 --profile C26270T S:G339D --sequencing_tech ILLUMINA --format csv
 ```
 
 ## Deleting Reference
 
-The `delete-ref` subcommand is used to delete reference genome sequences from the database.
+The `reference delete` subcommand is used to delete reference genome sequences from the database.
 
 ```sh
-sonar-cli delete-ref -r MN908947.3
+sonar-cli reference delete -r MN908947.3
 ```
 
 ## Listing Reference
 
-The `list-ref` is used to list available reference genome sequences in the database.
+The `reference list` is used to list available reference genome sequences in the database.
 
 ```sh
-sonar-cli list-ref
+sonar-cli reference list
 ```
 
 ## Listing Property
 
-The `list-prop` is used to list properties associated with genome sequences in the database.
+The `property list` is used to list properties associated with genome sequences in the database.
 
 ```sh
-sonar-cli list-prop
+sonar-cli property list
 ```
 
 ## Adding Property
 
-The `add-prop` subcommand is used to add properties to genome sequences in the database.
+The `property add` subcommand is used to add properties to genome sequences in the database.
 
 ```sh
-sonar-cli add-prop --name test-prop --descr "hello world" --dtype value_varchar
+sonar-cli property add --name test-prop --descr "hello world" --dtype value_varchar
 ```
 
 ## Deleting Property
 
-The `delete-prop` subcommand is used to delete properties from genome sequences in the database.
+The `property delete` subcommand is used to delete properties from genome sequences in the database.
 
 ```sh
-sonar-cli delete-prop --name test-prop  --force
+sonar-cli property delete --name test-prop  --force
 ```
 
 ## Deleting Sample
 
-The `delete-sample` is used to delete sample and associated information from the database.
+The `sample delete` is used to delete sample and associated information from the database.
 
 User provides a sample ID using the `--sample` option or combine multiple IDs together with a file name using the `--sample-file` option (one ID per line in a file).
 
 ```sh
-sonar-cli delete-sample --sample IMS-10116-CVDP-77AB96B7-B9FB-46D6-B844-F9356151F2CA --sample-file goodbye.txt
+sonar-cli sample delete --sample IMS-10116-CVDP-77AB96B7-B9FB-46D6-B844-F9356151F2CA --sample-file goodbye.txt
 ```
 
 ---

--- a/apps/cli/scripts/linux/update-cli.sh
+++ b/apps/cli/scripts/linux/update-cli.sh
@@ -9,4 +9,4 @@ echo "Make sure you do 'git pull' to update the code before running this command
 conda env update -n "$CONDA_ENV" -f environment.yml --prune
 conda run -n "$CONDA_ENV" poetry install --only main
 echo "Update complete. Testing to see if we can access the backend..."
-conda run -n "$CONDA_ENV" sonar-cli list-ref
+conda run -n "$CONDA_ENV" sonar-cli reference list

--- a/apps/cli/src/sonar_cli/basic.py
+++ b/apps/cli/src/sonar_cli/basic.py
@@ -502,7 +502,7 @@ def _check_property(db=None, prop_name_list: list[str] = []):
             continue
         if k not in available_names_list:
             LOGGER.error(
-                f"Key '{k}' not found in database, please check the typo or add it (add-prop) or list all properties (list-prop)."
+                f"Key '{k}' not found in database, please check the typo or add it (property add) or list all properties (property list)."
             )
             sys.exit(1)
     first = "name"

--- a/apps/cli/src/sonar_cli/sonar.py
+++ b/apps/cli/src/sonar_cli/sonar.py
@@ -51,69 +51,108 @@ def parse_args(args=None):
     reference_parser = create_parser_reference()
     thread_parser = create_parser_thread()
     lineage_parser = create_parser_lineage()
-    # Create all subparsers for the command-line interface
-    subparsers = parser.add_subparsers(dest="command", required=True)
+    resource_subparsers = parser.add_subparsers(dest="resource", required=True)
 
-    # Reference parser
-    subparsers, _ = create_subparser_list_reference(
-        subparsers, database_parser, general_parser
+    reference_parser_root = resource_subparsers.add_parser(
+        "reference", help="Manage reference genomes in the database."
     )
-
-    subparsers, _ = create_subparser_add_prop(
-        subparsers, database_parser, property_parser, general_parser
+    reference_subparsers = reference_parser_root.add_subparsers(
+        dest="verb", required=True
     )
-    subparsers, _ = create_subparser_delete_prop(
-        subparsers, database_parser, property_parser, general_parser
+    reference_subparsers, _ = create_subparser_list_reference(
+        reference_subparsers, database_parser, general_parser
     )
-
-    subparsers, _ = create_subparser_add_reference(
-        subparsers, database_parser, general_parser
+    reference_subparsers, _ = create_subparser_add_reference(
+        reference_subparsers, database_parser, general_parser
     )
-    subparsers, _ = create_subparser_delete_reference(
-        subparsers, database_parser, reference_parser, general_parser
+    reference_subparsers, _ = create_subparser_delete_reference(
+        reference_subparsers, database_parser, reference_parser, general_parser
     )
 
-    # import parser
-    subparsers, _ = create_subparser_import(
-        subparsers, database_parser, thread_parser, reference_parser, general_parser
+    property_parser_root = resource_subparsers.add_parser(
+        "property", help="Manage queryable properties in the database."
+    )
+    property_subparsers = property_parser_root.add_subparsers(
+        dest="verb", required=True
+    )
+    property_subparsers, _ = create_subparser_list_prop(
+        property_subparsers, database_parser, general_parser
+    )
+    property_subparsers, _ = create_subparser_add_prop(
+        property_subparsers, database_parser, property_parser, general_parser
+    )
+    property_subparsers, _ = create_subparser_delete_prop(
+        property_subparsers, database_parser, property_parser, general_parser
     )
 
-    subparsers, _ = create_subparser_delete_sample(
-        subparsers, database_parser, sample_parser, general_parser
+    sample_parser_root = resource_subparsers.add_parser(
+        "sample", help="Import, match, and delete samples."
     )
-
-    subparsers, _ = create_subparser_delete_sequence(
-        subparsers, database_parser, sequence_parser, general_parser
+    sample_subparsers = sample_parser_root.add_subparsers(dest="verb", required=True)
+    sample_subparsers, _ = create_subparser_import(
+        sample_subparsers,
+        database_parser,
+        thread_parser,
+        reference_parser,
+        general_parser,
     )
-
-    # property
-    subparsers, _ = create_subparser_list_prop(
-        subparsers, database_parser, general_parser
-    )
-
-    # lineage
-    subparsers, _ = create_subparser_lineage_import(
-        subparsers, lineage_parser, output_parser, general_parser
-    )
-
-    # import-dataset
-    subparsers, _ = create_subparser_import_dataset(
-        subparsers, database_parser, thread_parser, reference_parser, general_parser
-    )
-
-    # match
-    subparsers, subparser_match = create_subparser_match(
-        subparsers,
+    sample_subparsers, subparser_match = create_subparser_match(
+        sample_subparsers,
         database_parser,
         reference_parser,
         sample_parser,
         output_parser,
         general_parser,
     )
-    # admin
-    subparsers, _ = create_subparser_tasks(subparsers, database_parser, general_parser)
+    sample_subparsers, _ = create_subparser_delete_sample(
+        sample_subparsers, database_parser, sample_parser, general_parser
+    )
 
-    subparsers, _ = create_subparser_info(subparsers, database_parser, general_parser)
+    sequence_parser_root = resource_subparsers.add_parser(
+        "sequence", help="Delete sequences from the database."
+    )
+    sequence_subparsers = sequence_parser_root.add_subparsers(
+        dest="verb", required=True
+    )
+    sequence_subparsers, _ = create_subparser_delete_sequence(
+        sequence_subparsers, database_parser, sequence_parser, general_parser
+    )
+
+    dataset_parser_root = resource_subparsers.add_parser(
+        "dataset", help="Download and import public datasets."
+    )
+    dataset_subparsers = dataset_parser_root.add_subparsers(dest="verb", required=True)
+    dataset_subparsers, _ = create_subparser_import_dataset(
+        dataset_subparsers,
+        database_parser,
+        thread_parser,
+        reference_parser,
+        general_parser,
+    )
+
+    lineage_parser_root = resource_subparsers.add_parser(
+        "lineage", help="Import lineage parent-child relationships."
+    )
+    lineage_subparsers = lineage_parser_root.add_subparsers(dest="verb", required=True)
+    lineage_subparsers, _ = create_subparser_lineage_import(
+        lineage_subparsers, lineage_parser, output_parser, general_parser
+    )
+
+    task_parser_root = resource_subparsers.add_parser(
+        "task", help="Query background job status."
+    )
+    task_subparsers = task_parser_root.add_subparsers(dest="verb", required=True)
+    task_subparsers, _ = create_subparser_tasks(
+        task_subparsers, database_parser, general_parser
+    )
+
+    info_parser_root = resource_subparsers.add_parser(
+        "info", help="Display database information and statistics."
+    )
+    info_subparsers = info_parser_root.add_subparsers(dest="verb", required=True)
+    info_subparsers, _ = create_subparser_info(
+        info_subparsers, database_parser, general_parser
+    )
     # version parser
     parser.add_argument(
         "-v",
@@ -150,9 +189,10 @@ def is_match_selected(namespace: Optional[argparse.Namespace] = None) -> bool:
     Returns:
         True if 'match' command is selected and 'db' attribute is present, False otherwise
     """
-    # Check if the 'match' command is selected and the 'db' attribute is present
-    match_selected = namespace.command == "match"
-    return match_selected
+    return (
+        getattr(namespace, "resource", None) == "sample"
+        and getattr(namespace, "verb", None) == "match"
+    )
 
 
 def create_parser_lineage() -> argparse.ArgumentParser:
@@ -210,7 +250,7 @@ def create_subparser_info(
     subparsers: argparse._SubParsersAction, *parent_parsers: argparse.ArgumentParser
 ) -> argparse.ArgumentParser:
     parser = subparsers.add_parser(
-        "info",
+        "show",
         parents=parent_parsers,
         help="Display database information and statistics.",
     )
@@ -223,7 +263,7 @@ def create_subparser_delete_reference(
 ) -> argparse.ArgumentParser:
     # Delete Reference.
     parser = subparsers.add_parser(
-        "delete-ref",
+        "delete",
         parents=parent_parsers,
         help="Deletes a reference from the database.",
     )
@@ -249,7 +289,7 @@ def create_subparser_delete_sample(
         argparse.ArgumentParser: The created 'delete_sample' subparser.
     """
     parser_delete_sample = subparsers.add_parser(
-        "delete-sample",
+        "delete",
         help="Deletes samples from the database",
         parents=parent_parsers,
     )
@@ -276,7 +316,7 @@ def create_subparser_delete_sequence(
         argparse.ArgumentParser: The created 'delete_sequence' subparser.
     """
     parser_delete_sequence = subparsers.add_parser(
-        "delete-sequence",
+        "delete",
         help="Deletes sequences from the database",
         parents=parent_parsers,
     )
@@ -410,53 +450,53 @@ def create_parser_thread() -> argparse.ArgumentParser:
 def create_subparser_tasks(
     subparsers: argparse._SubParsersAction, *parent_parsers: argparse.ArgumentParser
 ) -> argparse.ArgumentParser:
-    # View Reference.
-    parser = subparsers.add_parser(
-        "tasks",
+    list_parser = subparsers.add_parser(
+        "list",
         parents=parent_parsers,
-        help="Use this command to query job status",
-    )
-    mutually_exclusive_group = parser.add_mutually_exclusive_group()
-
-    # Option to list all job IDs
-    mutually_exclusive_group.add_argument(
-        "--list-jobs", help="List all job IDs", action="store_true"
+        help="List all known background jobs.",
     )
 
-    # Option to search for a specific job ID
-    mutually_exclusive_group.add_argument(
-        "--jobid", help="Search for a specific job ID", type=str, default=None
+    show_parser = subparsers.add_parser(
+        "show",
+        parents=parent_parsers,
+        help="Show the status of a specific background job.",
     )
-    # Add subparsers for jobid specific commands
-    jobid_subparsers = parser.add_subparsers(dest="jobid_command")
-    # Subcommand for running in the background
-    jobid_background_parser = jobid_subparsers.add_parser(
-        "background", help="Run background checks periodically for the specified job"
+    show_parser.add_argument(
+        "--jobid", help="Search for a specific job ID", type=str, required=True
     )
-    jobid_background_parser.add_argument(
+
+    watch_parser = subparsers.add_parser(
+        "watch",
+        parents=parent_parsers,
+        help="Run background checks periodically for the specified job.",
+    )
+    watch_parser.add_argument(
+        "--jobid", help="Search for a specific job ID", type=str, required=True
+    )
+    watch_parser.add_argument(
         "--interval",
         help="Interval in seconds to check the job status (default: %(default)s)",
         type=int,
         default=60,
     )
-    return subparsers, parser
+    return subparsers, list_parser
 
 
 def create_subparser_list_prop(
     subparsers: argparse._SubParsersAction, *parent_parsers: argparse.ArgumentParser
 ) -> argparse.ArgumentParser:
     """
-    Creates a 'list-prop' subparser with command-specific arguments and options for the command-line interface.
+    Creates the 'property list' subparser with command-specific arguments and options for the command-line interface.
 
     Args:
-        subparsers (argparse._SubParsersAction): ArgumentParser object to attach the 'list-prop' subparser to.
+        subparsers (argparse._SubParsersAction): ArgumentParser object to attach the 'list' subparser to.
         parent_parsers (argparse.ArgumentParser): ArgumentParser objects providing common arguments and options.
 
     Returns:
-        argparse.ArgumentParser: The created 'list-prop' subparser.
+        argparse.ArgumentParser: The created 'property list' subparser.
     """
     parser = subparsers.add_parser(
-        "list-prop",
+        "list",
         help="Lists all sample properties added to the database",
         parents=parent_parsers,
     )
@@ -468,7 +508,7 @@ def create_subparser_list_reference(
 ) -> argparse.ArgumentParser:
     # View Reference.
     parser = subparsers.add_parser(
-        "list-ref",
+        "list",
         parents=parent_parsers,
         help="Lists all available references in the database",
     )
@@ -479,7 +519,7 @@ def create_subparser_lineage_import(
     subparsers: argparse._SubParsersAction, *parent_parsers: argparse.ArgumentParser
 ) -> argparse.ArgumentParser:
     parser = subparsers.add_parser(
-        "import-lineage",
+        "import",
         parents=parent_parsers,
         help="Perform lineage import to the database",
     )
@@ -490,17 +530,17 @@ def create_subparser_import_dataset(
     subparsers: argparse._SubParsersAction, *parent_parsers: argparse.ArgumentParser
 ) -> argparse.ArgumentParser:
     """
-    Creates an 'import-dataset' subparser for downloading and importing public datasets.
+    Creates the 'dataset import' subparser for downloading and importing public datasets.
 
     Args:
         subparsers (argparse._SubParsersAction): ArgumentParser object to attach the subparser to.
         parent_parsers (argparse.ArgumentParser): ArgumentParser objects providing common arguments.
 
     Returns:
-        argparse.ArgumentParser: The created 'import-dataset' subparser.
+        argparse.ArgumentParser: The created 'dataset import' subparser.
     """
     parser = subparsers.add_parser(
-        "import-dataset",
+        "import",
         parents=parent_parsers,
         help="Download and import public pathogen genomics datasets",
         description=(
@@ -719,7 +759,7 @@ def create_subparser_add_reference(
     subparsers: argparse._SubParsersAction, *parent_parsers: argparse.ArgumentParser
 ) -> argparse.ArgumentParser:
     parser = subparsers.add_parser(
-        "add-ref",
+        "add",
         parents=parent_parsers,
         help="Adds reference genome to the database.",
     )
@@ -731,7 +771,7 @@ def create_subparser_add_reference(
             "however, in a case of a segmented genome (multiple genbank files), user can provide multiple files. "
             "For example, --gb InfluenzaA_H1N1_seg1.gb InfluenzaA_H1N1_seg2.gb InfluenzaA_H1N1_seg7.gb ... "
             "This will automatically treat this import as a segmented genome, and the first file will be used as the "
-            "index in the reference table and shown information in ref-list command."
+            "index in the reference table and shown information in the reference list command."
         ),
         type=str,
         nargs="+",
@@ -746,17 +786,17 @@ def create_subparser_add_prop(
     subparsers: argparse._SubParsersAction, *parent_parsers: argparse.ArgumentParser
 ) -> argparse.ArgumentParser:
     """
-    Creates an 'add-prop' subparser with command-specific arguments and options for the command-line interface.
+    Creates the 'property add' subparser with command-specific arguments and options for the command-line interface.
 
     Args:
-        subparsers (argparse._SubParsersAction): ArgumentParser object to attach the 'add-prop' subparser to.
+        subparsers (argparse._SubParsersAction): ArgumentParser object to attach the 'add' subparser to.
         parent_parsers (argparse.ArgumentParser): ArgumentParser objects providing common arguments and options.
 
     Returns:
-        argparse.ArgumentParser: The created 'add-prop' subparser.
+        argparse.ArgumentParser: The created 'property add' subparser.
     """
     parser = subparsers.add_parser(
-        "add-prop", help="add a property to the database", parents=parent_parsers
+        "add", help="add a property to the database", parents=parent_parsers
     )
     parser.add_argument(
         "--descr",
@@ -812,17 +852,17 @@ def create_subparser_delete_prop(
     subparsers: argparse._SubParsersAction, *parent_parsers: argparse.ArgumentParser
 ) -> argparse.ArgumentParser:
     """
-    Creates an 'delete-prop' subparser with command-specific arguments and options for the command-line interface.
+    Creates the 'property delete' subparser with command-specific arguments and options for the command-line interface.
 
     Args:
-        subparsers (argparse._SubParsersAction): ArgumentParser object to attach the 'delete-prop' subparser to.
+        subparsers (argparse._SubParsersAction): ArgumentParser object to attach the 'delete' subparser to.
         parent_parsers (argparse.ArgumentParser): ArgumentParser objects providing common arguments and options.
 
     Returns:
-        argparse.ArgumentParser: The created 'delete-prop' subparser.
+        argparse.ArgumentParser: The created 'property delete' subparser.
     """
     parser = subparsers.add_parser(
-        "delete-prop", help="delete a property to the database", parents=parent_parsers
+        "delete", help="delete a property to the database", parents=parent_parsers
     )
     parser.add_argument(
         "--force",
@@ -935,7 +975,7 @@ def handle_import(args: argparse.Namespace):
         LOGGER.info("Alignment Tool: WFA2-lib")
     else:
         LOGGER.warning(
-            "Invalid --method. Please use 'import -h' to see available methods"
+            "Invalid --method. Please use 'sample import -h' to see available methods"
         )
         exit(1)
     LOGGER.info(f"Skip N/X mutation: {args.skip_nx}")
@@ -1199,7 +1239,7 @@ def handle_add_prop(args: argparse.Namespace):
 
 
 def handle_tasks(args: argparse.Namespace):
-    if args.list_jobs:
+    if args.verb == "list":
         print(
             tabulate(
                 sonarUtils1.get_all_jobs(db=args.db),
@@ -1207,19 +1247,13 @@ def handle_tasks(args: argparse.Namespace):
                 tablefmt="fancy_grid",
             )
         )
-    elif args.jobid:
-        if args.jobid_command:
-            result, status = sonarUtils1.get_job_byID(
-                db=args.db,
-                job_id=args.jobid,
-                background=args.jobid_command == "background",
-                interval=args.interval,
-            )
-        else:
-            result, status = sonarUtils1.get_job_byID(
-                db=args.db,
-                job_id=args.jobid,
-            )
+    elif args.verb in {"show", "watch"}:
+        result, status = sonarUtils1.get_job_byID(
+            db=args.db,
+            job_id=args.jobid,
+            background=args.verb == "watch",
+            interval=getattr(args, "interval", 60),
+        )
         print("Status:", status)
         print(
             tabulate(
@@ -1343,48 +1377,33 @@ def execute_commands(args):  # noqa: C901
         args (argparse.Namespace): Parsed command line arguments.
     """
     LOGGER.info(f"Current version {NAME}:{VERSION}")
-    if args.command == "import":
-        if len(sys.argv[1:]) == 1:
-            parse_args(["import", "-h"])
-        else:
-            handle_import(args)
-    elif args.command == "add-ref":
+    if args.resource == "sample" and args.verb == "import":
+        handle_import(args)
+    elif args.resource == "reference" and args.verb == "add":
         handle_add_ref(args)
-    elif args.command == "list-ref":
+    elif args.resource == "reference" and args.verb == "list":
         handle_list_ref(args)
-    elif args.command == "delete-ref":
+    elif args.resource == "reference" and args.verb == "delete":
         handle_delete_ref(args)
-    elif args.command == "list-prop":
+    elif args.resource == "property" and args.verb == "list":
         handle_list_prop(args)
-    elif args.command == "add-prop":
+    elif args.resource == "property" and args.verb == "add":
         handle_add_prop(args)
-    elif args.command == "delete-prop":
+    elif args.resource == "property" and args.verb == "delete":
         handle_delete_prop(args)
-    elif args.command == "match":
-        if len(sys.argv[1:]) == 1:
-            parse_args(["match", "-h"])
-        else:
-            handle_match(args)
-    elif args.command == "delete-sample":
-        if len(sys.argv[1:]) == 1:
-            parse_args(["delete-sample", "-h"])
-        else:
-            handle_delete_sample(args)
-    elif args.command == "delete-sequence":
-        if len(sys.argv[1:]) == 1:
-            parse_args(["delete-sequence", "-h"])
-        else:
-            handle_delete_sequence(args)
-    elif args.command == "tasks":
+    elif args.resource == "sample" and args.verb == "match":
+        handle_match(args)
+    elif args.resource == "sample" and args.verb == "delete":
+        handle_delete_sample(args)
+    elif args.resource == "sequence" and args.verb == "delete":
+        handle_delete_sequence(args)
+    elif args.resource == "task":
         handle_tasks(args)
-    elif args.command == "import-lineage":
+    elif args.resource == "lineage" and args.verb == "import":
         handle_lineage(args)
-    elif args.command == "import-dataset":
-        if len(sys.argv[1:]) == 1:
-            parse_args(["import-dataset", "-h"])
-        else:
-            handle_import_dataset(args)
-    elif args.command == "info":
+    elif args.resource == "dataset" and args.verb == "import":
+        handle_import_dataset(args)
+    elif args.resource == "info" and args.verb == "show":
         handle_info(args)
 
 

--- a/apps/cli/src/sonar_cli/utils.py
+++ b/apps/cli/src/sonar_cli/utils.py
@@ -1061,7 +1061,7 @@ class sonarUtils:
                     }
                 else:
                     LOGGER.warning(
-                        f"Property '{prop}' is unknown. Use 'list-prop' to see all valid properties or 'add-prop' to add it before import."
+                        f"Property '{prop}' is unknown. Use 'property list' to see all valid properties or 'property add' to add it before import."
                     )
         # Check if columns exist in the provided CSV/TSV files
         # only existing columns shall pass

--- a/apps/cli/tests/sars-cov-2/mktestdb.sh
+++ b/apps/cli/tests/sars-cov-2/mktestdb.sh
@@ -9,28 +9,28 @@ set -x
 # setting database up
 rm -f test.db
 sonar setup --db test.db
-sonar add-prop --db test.db --name SENDING_LAB --dtype integer --descr descr
-sonar add-prop --db test.db --name DATE_DRAW --dtype date --descr descr
-sonar add-prop --db test.db --name SEQ_TYPE --dtype text --descr descr
-sonar add-prop --db test.db --name SEQ_REASON --dtype text --descr descr
-sonar add-prop --db test.db --name SAMPLE_TYPE --dtype text --descr descr
-sonar add-prop --db test.db --name OWN_FASTA_ID --dtype text --descr descr
-sonar add-prop --db test.db --name DOWNLOAD_ID --dtype text --descr descr
-sonar add-prop --db test.db --name DEMIS_ID --dtype integer --descr descr
-sonar add-prop --db test.db --name RECEIVE_DATE --dtype date --descr descr
-sonar add-prop --db test.db --name PROCESSING_DATE --dtype date --descr descr
-sonar add-prop --db test.db --name PUBLICATION_STATUS --dtype text --descr descr
-sonar add-prop --db test.db --name HASHED_SEQUENCE --dtype text --descr descr
-sonar add-prop --db test.db --name TIMESTAMP --dtype text --descr descr
-sonar add-prop --db test.db --name STUDY --dtype text --descr descr
-sonar add-prop --db test.db --name DOWNLOADING_TIMESTAMP --dtype text --descr descr
-sonar add-prop --db test.db --name SENDING_LAB_PC --dtype zip --descr descr
-sonar add-prop --db test.db --name DEMIS_ID_PC --dtype zip --descr descr
-sonar add-prop --db test.db --name VERSION --dtype integer --descr descr
-sonar add-prop --db test.db --name DESH_QC_PASSED --dtype text --descr descr
-sonar add-prop --db test.db --name DESH_REJECTION_REASON --dtype text --descr descr
-sonar add-prop --db test.db --name DUPLICATE_ID --dtype text --descr descr
-sonar add-prop --db test.db --name LINEAGE --dtype text --descr descr
+sonar property add --db test.db --name SENDING_LAB --dtype integer --descr descr
+sonar property add --db test.db --name DATE_DRAW --dtype date --descr descr
+sonar property add --db test.db --name SEQ_TYPE --dtype text --descr descr
+sonar property add --db test.db --name SEQ_REASON --dtype text --descr descr
+sonar property add --db test.db --name SAMPLE_TYPE --dtype text --descr descr
+sonar property add --db test.db --name OWN_FASTA_ID --dtype text --descr descr
+sonar property add --db test.db --name DOWNLOAD_ID --dtype text --descr descr
+sonar property add --db test.db --name DEMIS_ID --dtype integer --descr descr
+sonar property add --db test.db --name RECEIVE_DATE --dtype date --descr descr
+sonar property add --db test.db --name PROCESSING_DATE --dtype date --descr descr
+sonar property add --db test.db --name PUBLICATION_STATUS --dtype text --descr descr
+sonar property add --db test.db --name HASHED_SEQUENCE --dtype text --descr descr
+sonar property add --db test.db --name TIMESTAMP --dtype text --descr descr
+sonar property add --db test.db --name STUDY --dtype text --descr descr
+sonar property add --db test.db --name DOWNLOADING_TIMESTAMP --dtype text --descr descr
+sonar property add --db test.db --name SENDING_LAB_PC --dtype zip --descr descr
+sonar property add --db test.db --name DEMIS_ID_PC --dtype zip --descr descr
+sonar property add --db test.db --name VERSION --dtype integer --descr descr
+sonar property add --db test.db --name DESH_QC_PASSED --dtype text --descr descr
+sonar property add --db test.db --name DESH_REJECTION_REASON --dtype text --descr descr
+sonar property add --db test.db --name DUPLICATE_ID --dtype text --descr descr
+sonar property add --db test.db --name LINEAGE --dtype text --descr descr
 cp test.db test-with-seqs.db
-sonar import --db test-with-seqs.db --tsv ../../../../test-data/sars-cov-2/SARS-CoV-2_6.tsv --fasta ../../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cols sample=IMS_ID --cache cache --threads 1
+sonar sample import --db test-with-seqs.db --tsv ../../../../test-data/sars-cov-2/SARS-CoV-2_6.tsv --fasta ../../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cols sample=IMS_ID --cache cache --threads 1
 rm -rf cache import.log

--- a/apps/cli/tests/test_config.py
+++ b/apps/cli/tests/test_config.py
@@ -72,7 +72,7 @@ def test_sonar_main_sets_db_override(monkeypatch, tmp_path):
         lambda args: captured.setdefault("url", config.get_base_url()),
     )
 
-    sonar.main(sonar.parse_args(["info", "--db", "http://cli.example/api"]))
+    sonar.main(sonar.parse_args(["info", "show", "--db", "http://cli.example/api"]))
 
     assert captured["url"] == "http://cli.example/api"
 

--- a/apps/cli/tests/test_e2e.py
+++ b/apps/cli/tests/test_e2e.py
@@ -22,7 +22,7 @@ def test_version():
 
 def test_info(capfd, api_url):
     """Test that info command works without KeyError"""
-    code = run_cli(f" info --db {api_url} ")
+    code = run_cli(f" info show --db {api_url} ")
     out, err = capfd.readouterr()
     # Check that basic statistics are present
     assert "Samples Total:" in err
@@ -35,15 +35,15 @@ def test_info(capfd, api_url):
 
 
 def test_get_list_prop(capfd, api_url):
-    code = run_cli(f" list-prop --db {api_url} ")
+    code = run_cli(f" property list --db {api_url} ")
     out, err = capfd.readouterr()
     assert "name" in out
     assert code == 0
 
 
 def test_get_list_prop_has_length(capfd, api_url):
-    """Test that length property is visible in list-prop output"""
-    code = run_cli(f" list-prop --db {api_url} ")
+    """Test that length property is visible in property list output"""
+    code = run_cli(f" property list --db {api_url} ")
     out, err = capfd.readouterr()
     assert "length" in out
     assert "Sequence length in base pairs" in out
@@ -51,7 +51,7 @@ def test_get_list_prop_has_length(capfd, api_url):
 
 
 def test_get_list_ref(capfd, api_url):
-    code = run_cli(f" list-ref --db {api_url} ")
+    code = run_cli(f" reference list --db {api_url} ")
     out, err = capfd.readouterr()
     assert "accession" in out
     assert code == 0
@@ -61,7 +61,7 @@ def test_get_list_ref(capfd, api_url):
 @pytest.mark.order(1)
 def test_add_prop_varchar(capfd, api_url):
     code = run_cli(
-        f" add-prop --db {api_url} --name test_varchar --dtype value_varchar --descr 'test-varchar' "
+        f" property add --db {api_url} --name test_varchar --dtype value_varchar --descr 'test-varchar' "
     )
     out, err = capfd.readouterr()
     assert "successfully" in err
@@ -72,7 +72,7 @@ def test_add_prop_varchar(capfd, api_url):
 @pytest.mark.order(2)
 def test_add_prop_int(capfd, api_url):
     code = run_cli(
-        f" add-prop --db {api_url} --name test_integer --dtype value_integer --descr 'test-integer' "
+        f" property add --db {api_url} --name test_integer --dtype value_integer --descr 'test-integer' "
     )
     out, err = capfd.readouterr()
     assert "successfully" in err
@@ -83,7 +83,7 @@ def test_add_prop_int(capfd, api_url):
 @pytest.mark.order(3)
 def test_add_prop_float(capfd, api_url):
     code = run_cli(
-        f" add-prop --db {api_url} --name test_float --dtype value_float --descr 'test-floating-point-number' "
+        f" property add --db {api_url} --name test_float --dtype value_float --descr 'test-floating-point-number' "
     )
     out, err = capfd.readouterr()
     assert "successfully" in err
@@ -94,7 +94,7 @@ def test_add_prop_float(capfd, api_url):
 @pytest.mark.order(4)
 def test_add_prop_text(capfd, api_url):
     code = run_cli(
-        f" add-prop --db {api_url} --name test_text --dtype value_text --descr 'test-text' "
+        f" property add --db {api_url} --name test_text --dtype value_text --descr 'test-text' "
     )
     out, err = capfd.readouterr()
     assert "successfully" in err
@@ -105,7 +105,7 @@ def test_add_prop_text(capfd, api_url):
 @pytest.mark.order(5)
 def test_add_prop_zip(capfd, api_url):
     code = run_cli(
-        f" add-prop --db {api_url} --name test_zip --dtype value_zip --descr 'test-zip' "
+        f" property add --db {api_url} --name test_zip --dtype value_zip --descr 'test-zip' "
     )
     out, err = capfd.readouterr()
     assert "successfully" in err
@@ -116,7 +116,7 @@ def test_add_prop_zip(capfd, api_url):
 @pytest.mark.order(6)
 def test_add_prop_date(capfd, api_url):
     code = run_cli(
-        f" add-prop --db {api_url} --name test_date --dtype value_date --descr 'test-date' "
+        f" property add --db {api_url} --name test_date --dtype value_date --descr 'test-date' "
     )
     out, err = capfd.readouterr()
     assert "successfully" in err
@@ -126,32 +126,32 @@ def test_add_prop_date(capfd, api_url):
 @pytest.mark.xdist_group(name="group_prop")
 @pytest.mark.order(8)
 def test_delete_prop_varchar(capfd, api_url):
-    code = run_cli(f" delete-prop --db {api_url} --name test_varchar --force ")
+    code = run_cli(f" property delete --db {api_url} --name test_varchar --force ")
     out, err = capfd.readouterr()
     assert "successfully" in err
     assert code == 0
 
-    code = run_cli(f" delete-prop --db {api_url} --name test_integer --force ")
+    code = run_cli(f" property delete --db {api_url} --name test_integer --force ")
     out, err = capfd.readouterr()
     assert "successfully" in err
     assert code == 0
 
-    code = run_cli(f" delete-prop --db {api_url} --name test_float --force ")
+    code = run_cli(f" property delete --db {api_url} --name test_float --force ")
     out, err = capfd.readouterr()
     assert "successfully" in err
     assert code == 0
 
-    code = run_cli(f" delete-prop --db {api_url} --name test_text --force ")
+    code = run_cli(f" property delete --db {api_url} --name test_text --force ")
     out, err = capfd.readouterr()
     assert "successfully" in err
     assert code == 0
 
-    code = run_cli(f" delete-prop --db {api_url} --name test_zip --force ")
+    code = run_cli(f" property delete --db {api_url} --name test_zip --force ")
     out, err = capfd.readouterr()
     assert "successfully" in err
     assert code == 0
 
-    code = run_cli(f" delete-prop --db {api_url} --name test_date --force ")
+    code = run_cli(f" property delete --db {api_url} --name test_date --force ")
     out, err = capfd.readouterr()
     assert "successfully" in err
     assert code == 0
@@ -160,7 +160,7 @@ def test_delete_prop_varchar(capfd, api_url):
 def test_add_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/influenza/H7N9/InfluA_H7N9_seg6.gb"
-    code = run_cli(f" add-ref --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -168,7 +168,7 @@ def test_add_ref(monkeypatch, capfd, api_url):
 
 def test_delete_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
-    code = run_cli(f" delete-ref --db {api_url} -r NC_026429.1 --force")
+    code = run_cli(f" reference delete --db {api_url} -r NC_026429.1 --force")
     out, err = capfd.readouterr()
     assert "Reference deleted." in err
     assert code == 0
@@ -177,7 +177,7 @@ def test_delete_ref(monkeypatch, capfd, api_url):
 def test_delete_sample_fromfile(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     code = run_cli(
-        f"delete-sample --db {api_url} --sample-file sars-cov-2/sample_list.2.txt --force"
+        f"sample delete --db {api_url} --sample-file sars-cov-2/sample_list.2.txt --force"
     )
     out, err = capfd.readouterr()
     assert "0 of 2 samples found and deleted." in err
@@ -186,7 +186,7 @@ def test_delete_sample_fromfile(monkeypatch, capfd, api_url):
 
 def test_output_csv_format(capfd, api_url, tmpfile_name):
     code = run_cli(
-        f" match --db {api_url} -r MN908947.3 --profile S:N440K C24503T --format csv -o {tmpfile_name}/out.csv "
+        f" sample match --db {api_url} -r MN908947.3 --profile S:N440K C24503T --format csv -o {tmpfile_name}/out.csv "
     )
     assert os.path.exists(f"{tmpfile_name}/out.csv") is True
     assert code == 0

--- a/apps/cli/tests/test_e2e_import.py
+++ b/apps/cli/tests/test_e2e_import.py
@@ -11,7 +11,7 @@ from .conftest import run_cli
 def test_add_cov19_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/sars-cov-2/MN908947.nextclade.gb"
-    code = run_cli(f" add-ref --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -22,7 +22,7 @@ def test_add_cov19_ref(monkeypatch, capfd, api_url):
 def test_add_mpox_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/mpox/clade-IIb-NC_063383.1.gb"
-    code = run_cli(f" add-ref --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -33,7 +33,7 @@ def test_add_mpox_ref(monkeypatch, capfd, api_url):
 def test_add_rsv_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/RSV/RSV-B/OP975389.1.gb"
-    code = run_cli(f" add-ref --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -44,7 +44,7 @@ def test_add_rsv_ref(monkeypatch, capfd, api_url):
 def test_add_measels_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/morbillivirus-hominis/NC_001498.gb"
-    code = run_cli(f" add-ref --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -55,7 +55,7 @@ def test_add_measels_ref(monkeypatch, capfd, api_url):
 def test_add_hiv_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/HIV/NC_001802.1.gb"
-    code = run_cli(f" add-ref --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -66,7 +66,7 @@ def test_add_hiv_ref(monkeypatch, capfd, api_url):
 def test_add_dengue_type2_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/dengue/type_2/NC_001474.2.gb"
-    code = run_cli(f" add-ref --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -77,7 +77,7 @@ def test_add_dengue_type2_ref(monkeypatch, capfd, api_url):
 def test_add_ebola_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/ebola/NC_002549.1.gb"
-    code = run_cli(f" add-ref --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -88,7 +88,7 @@ def test_add_ebola_ref(monkeypatch, capfd, api_url):
 def test_add_zika_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/zika/NC_035889.gb"
-    code = run_cli(f" add-ref --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -109,7 +109,7 @@ def test_add_influ_gbk(monkeypatch, capfd, api_url):
     new_ref_file += " ../../../test-data/influenza/influenza-A/H1N1PDM_California/segment_7_NC_026431.gb"
     new_ref_file += " ../../../test-data/influenza/influenza-A/H1N1PDM_California/segment_8_NC_026432.1.gb"
 
-    code = run_cli(f" add-ref --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -121,7 +121,7 @@ def test_add_influ_gbk(monkeypatch, capfd, api_url):
 def test_parasail_no_anno_no_upload(monkeypatch, api_url, tmpfile_name):
     """Test import command using parasail method"""
     monkeypatch.chdir(Path(__file__).parent)
-    command = f"import --db {api_url} -r MN908947.3 --method parasail --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/parasail -t 2 --no-upload --must-pass-paranoid"
+    command = f"sample import --db {api_url} -r MN908947.3 --method parasail --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/parasail -t 2 --no-upload --must-pass-paranoid"
     try:
         code = run_cli(command)
     except SystemExit as e:
@@ -134,7 +134,7 @@ def test_parasail_no_anno_no_upload(monkeypatch, api_url, tmpfile_name):
 def test_mafft_no_anno_no_upload(monkeypatch, api_url, tmpfile_name):
     """Test import command using mafft method"""
     monkeypatch.chdir(Path(__file__).parent)
-    command = f"import --db {api_url} -r MN908947.3 --method mafft --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/mafft -t 2 --no-upload --must-pass-paranoid"
+    command = f"sample import --db {api_url} -r MN908947.3 --method mafft --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/mafft -t 2 --no-upload --must-pass-paranoid"
     try:
         code = run_cli(command)
     except SystemExit as e:
@@ -153,7 +153,7 @@ def test_add_sequence_mafft_anno_prop(monkeypatch, api_url, tmpfile_name):
     #         func(** arg) for arg in args
     #     ),
     # )
-    command = f"import --db {api_url} -r MN908947.3 --method mafft --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/mafft -t 2 --auto-anno --tsv ../../../test-data/sars-cov-2/SARS-CoV-2_6.tsv --cols name=IMS_ID collection_date=DATE_DRAW sequencing_tech=SEQ_REASON sample_type=SAMPLE_TYPE --must-pass-paranoid"
+    command = f"sample import --db {api_url} -r MN908947.3 --method mafft --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/mafft -t 2 --auto-anno --tsv ../../../test-data/sars-cov-2/SARS-CoV-2_6.tsv --cols name=IMS_ID collection_date=DATE_DRAW sequencing_tech=SEQ_REASON sample_type=SAMPLE_TYPE --must-pass-paranoid"
     code = run_cli(command)
 
     assert code == 0
@@ -165,7 +165,7 @@ def test_add_sequence_mafft_no_skip(monkeypatch, api_url, tmpfile_name):
     monkeypatch.chdir(Path(__file__).parent)
 
     code = run_cli(
-        f"import --db {api_url} -r MN908947.3 --method mafft --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/mafft  --no-skip --no-upload --must-pass-paranoid"
+        f"sample import --db {api_url} -r MN908947.3 --method mafft --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/mafft  --no-skip --no-upload --must-pass-paranoid"
     )
     assert code == 0
 
@@ -176,7 +176,7 @@ def test_add_sequence_mafft_skip(monkeypatch, api_url, tmpfile_name):
     monkeypatch.chdir(Path(__file__).parent)
 
     code = run_cli(
-        f"import --db {api_url} -r MN908947.3 --method mafft --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/mafft -t 1 --no-upload --must-pass-paranoid"
+        f"sample import --db {api_url} -r MN908947.3 --method mafft --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/mafft -t 1 --no-upload --must-pass-paranoid"
     )
     assert code == 0
 
@@ -187,7 +187,7 @@ def test_mafft_anno_upload_rsv(monkeypatch, api_url, tmpfile_name):
     """Test rsv sequence import command using mafft method"""
     monkeypatch.chdir(Path(__file__).parent)
 
-    command = f"import --db {api_url} -r OP975389.1 --method mafft --fasta ../../../test-data/RSV/RSV_20.fasta.xz --cache {tmpfile_name}/mafft -t 2 --skip-nx --must-pass-paranoid"
+    command = f"sample import --db {api_url} -r OP975389.1 --method mafft --fasta ../../../test-data/RSV/RSV_20.fasta.xz --cache {tmpfile_name}/mafft -t 2 --skip-nx --must-pass-paranoid"
     code = run_cli(command)
     assert code == 0
 
@@ -196,7 +196,7 @@ def test_mafft_anno_upload_rsv(monkeypatch, api_url, tmpfile_name):
 @pytest.mark.order(3)
 def test_add_rsv_samples(monkeypatch, api_url, tmpfile_name):
     monkeypatch.chdir(Path(__file__).parent)
-    command = f"import --db {api_url} -r OP975389.1 --tsv ../../../test-data/RSV/RSV_20.tsv --cache {tmpfile_name}/mafft --cols name=name"
+    command = f"sample import --db {api_url} -r OP975389.1 --tsv ../../../test-data/RSV/RSV_20.tsv --cache {tmpfile_name}/mafft --cols name=name"
     code = run_cli(command)
 
     assert code == 0
@@ -208,9 +208,9 @@ def test_mafft_anno_upload_mpox(monkeypatch, api_url, tmpfile_name):
     """Test mpox sequence import command using mafft method"""
     monkeypatch.chdir(Path(__file__).parent)
 
-    command_import = f"import --db {api_url} -r NC_063383.1 --method mafft --fasta ../../../test-data/mpox/mpox_2.fasta.xz --cache {tmpfile_name}/mafft -t 2 --skip-nx --must-pass-paranoid"
+    command_import = f"sample import --db {api_url} -r NC_063383.1 --method mafft --fasta ../../../test-data/mpox/mpox_2.fasta.xz --cache {tmpfile_name}/mafft -t 2 --skip-nx --must-pass-paranoid"
     code = run_cli(command_import)
-    command_samples = f"import --db {api_url} -r NC_063383.1 --tsv ../../../test-data/mpox/mpox_2.tsv --cache {tmpfile_name}/mafft --cols name=name"
+    command_samples = f"sample import --db {api_url} -r NC_063383.1 --tsv ../../../test-data/mpox/mpox_2.tsv --cache {tmpfile_name}/mafft --cols name=name"
     code = run_cli(command_samples)
     assert code == 0
 
@@ -221,9 +221,9 @@ def test_mafft_anno_upload_ebola(monkeypatch, api_url, tmpfile_name):
     """Test ebola sample import command using mafft method"""
     monkeypatch.chdir(Path(__file__).parent)
 
-    command_import = f"import --db {api_url} -r NC_002549.1 --method mafft --fasta ../../../test-data/ebola/ebola_20.fasta.xz --cache {tmpfile_name}/mafft -t 2 --skip-nx --must-pass-paranoid"
+    command_import = f"sample import --db {api_url} -r NC_002549.1 --method mafft --fasta ../../../test-data/ebola/ebola_20.fasta.xz --cache {tmpfile_name}/mafft -t 2 --skip-nx --must-pass-paranoid"
     code = run_cli(command_import)
-    command_samples = f"import --db {api_url} -r NC_002549.1 --tsv ../../../test-data/ebola/ebola_20.tsv --cache {tmpfile_name}/mafft --cols name=name"
+    command_samples = f"sample import --db {api_url} -r NC_002549.1 --tsv ../../../test-data/ebola/ebola_20.tsv --cache {tmpfile_name}/mafft --cols name=name"
     code = run_cli(command_samples)
     assert code == 0
 
@@ -234,9 +234,9 @@ def test_mafft_anno_upload_dengue_type2(monkeypatch, api_url, tmpfile_name):
     """Test dengue sample import command using mafft method"""
     monkeypatch.chdir(Path(__file__).parent)
 
-    command_import = f"import --db {api_url} -r NC_001474.2 --method mafft --fasta ../../../test-data/dengue/type_2/dengue_type2_complete_13.fasta.xz --cache {tmpfile_name}/mafft -t 2 --skip-nx --must-pass-paranoid"
+    command_import = f"sample import --db {api_url} -r NC_001474.2 --method mafft --fasta ../../../test-data/dengue/type_2/dengue_type2_complete_13.fasta.xz --cache {tmpfile_name}/mafft -t 2 --skip-nx --must-pass-paranoid"
     code = run_cli(command_import)
-    command_samples = f"import --db {api_url} -r NC_001474.2  --tsv ../../../test-data/dengue/type_2/dengue_type2_complete_13.tsv --cache {tmpfile_name}/mafft --cols name=name"
+    command_samples = f"sample import --db {api_url} -r NC_001474.2  --tsv ../../../test-data/dengue/type_2/dengue_type2_complete_13.tsv --cache {tmpfile_name}/mafft --cols name=name"
     code = run_cli(command_samples)
     assert code == 0
 
@@ -288,9 +288,9 @@ def test_mafft_upload_hiv(monkeypatch, api_url, tmpfile_name):
                 yield func(**data_dict)
 
     monkeypatch.setattr("mpire.WorkerPool.imap_unordered", smart_imap_unordered)
-    command_import = f"import --db {api_url} -r NC_001802.1 --method mafft --fasta ../../../test-data/HIV/HIV_20.fasta.xz --cache {tmpfile_name}/mafft -t 2 --skip-nx --must-pass-paranoid"
+    command_import = f"sample import --db {api_url} -r NC_001802.1 --method mafft --fasta ../../../test-data/HIV/HIV_20.fasta.xz --cache {tmpfile_name}/mafft -t 2 --skip-nx --must-pass-paranoid"
     code = run_cli(command_import)
-    command_samples = f"import --db {api_url} -r NC_001802.1 --tsv ../../../test-data/HIV/HIV_20.tsv --cache {tmpfile_name}/mafft --cols name=name"
+    command_samples = f"sample import --db {api_url} -r NC_001802.1 --tsv ../../../test-data/HIV/HIV_20.tsv --cache {tmpfile_name}/mafft --cols name=name"
     code = run_cli(command_samples)
     assert code == 0
 
@@ -306,7 +306,7 @@ def test_wfa_anno_no_upload_covid(monkeypatch, api_url, tmpfile_name):
     #         func(**arg) for arg in args
     #     ),
     # )
-    command = f"import --db {api_url} -r MN908947.3 --method wfa --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/wfa -t 1 --no-upload --auto-anno --must-pass-paranoid --skip-nx"
+    command = f"sample import --db {api_url} -r MN908947.3 --method wfa --fasta ../../../test-data/sars-cov-2/SARS-CoV-2_6.fasta.gz --cache {tmpfile_name}/wfa -t 1 --no-upload --auto-anno --must-pass-paranoid --skip-nx"
     code = run_cli(command)
 
     assert code == 0
@@ -321,7 +321,7 @@ def test_wfa_anno_no_upload_mpox(monkeypatch, api_url, tmpfile_name):
         "sonar_cli.config.FILTER_DELETE_SIZE", "200000"
     )  # we keep all sequences
 
-    command = f"import --db {api_url}  -r NC_063383.1 --method wfa --fasta ../../../test-data/mpox/mpox_20.fasta.xz --cache {tmpfile_name}/wfa -t 1 --no-upload --auto-anno --must-pass-paranoid --skip-nx"
+    command = f"sample import --db {api_url}  -r NC_063383.1 --method wfa --fasta ../../../test-data/mpox/mpox_20.fasta.xz --cache {tmpfile_name}/wfa -t 1 --no-upload --auto-anno --must-pass-paranoid --skip-nx"
     code = run_cli(command)
 
     assert code == 0
@@ -333,7 +333,7 @@ def test_add_prop_autolink(monkeypatch, api_url, tmpfile_name):
     """Test import command using autolink"""
     monkeypatch.chdir(Path(__file__).parent)
 
-    command = f"import --db {api_url} -r MN908947.3 --method mafft --cache {tmpfile_name}/mafft -t 1  --tsv sars-cov-2/meta_autolink.tsv --cols name=IMS_ID --auto-link"
+    command = f"sample import --db {api_url} -r MN908947.3 --method mafft --cache {tmpfile_name}/mafft -t 1  --tsv sars-cov-2/meta_autolink.tsv --cols name=IMS_ID --auto-link"
     code = run_cli(command)
 
     assert code == 0
@@ -345,7 +345,7 @@ def test_add_prop(monkeypatch, api_url, tmpfile_name):
     """Test import command using parasail method"""
     monkeypatch.chdir(Path(__file__).parent)
 
-    command = f"import --db {api_url} -r MN908947.3 --method mafft --cache {tmpfile_name}/mafft -t 2 --tsv ../../../test-data/sars-cov-2/SARS-CoV-2_6.tsv --cols name=IMS_ID collection_date=DATE_DRAW sequencing_tech=SEQ_TYPE sample_type=SAMPLE_TYPE"
+    command = f"sample import --db {api_url} -r MN908947.3 --method mafft --cache {tmpfile_name}/mafft -t 2 --tsv ../../../test-data/sars-cov-2/SARS-CoV-2_6.tsv --cols name=IMS_ID collection_date=DATE_DRAW sequencing_tech=SEQ_TYPE sample_type=SAMPLE_TYPE"
     code = run_cli(command)
 
     assert code == 0
@@ -355,7 +355,7 @@ def test_add_prop(monkeypatch, api_url, tmpfile_name):
 @pytest.mark.order(2)
 def test_add_influenza_sequences(monkeypatch, api_url, tmpfile_name):
     monkeypatch.chdir(Path(__file__).parent)
-    command = f"import --db {api_url} -r NC_026438.1 --method mafft --fasta ../../../test-data/influenza/influenza-A/H1N1PDM_California/H1N1.sequences.fasta.xz --cache {tmpfile_name}/mafft_influ -t 7 --auto-anno"
+    command = f"sample import --db {api_url} -r NC_026438.1 --method mafft --fasta ../../../test-data/influenza/influenza-A/H1N1PDM_California/H1N1.sequences.fasta.xz --cache {tmpfile_name}/mafft_influ -t 7 --auto-anno"
     code = run_cli(command)
 
     assert code == 0
@@ -365,7 +365,7 @@ def test_add_influenza_sequences(monkeypatch, api_url, tmpfile_name):
 @pytest.mark.order(3)
 def test_add_influenza_samples(monkeypatch, api_url, tmpfile_name):
     monkeypatch.chdir(Path(__file__).parent)
-    command = f"import --db {api_url} -r NC_026438.1 --tsv ../../../test-data/influenza/influenza-A/H1N1PDM_California/H1N1PDM.sequences.tsv --cache {tmpfile_name}/mafft_influ --cols name=name collection_date=date country=location lineage=lineages sequences=sequences"
+    command = f"sample import --db {api_url} -r NC_026438.1 --tsv ../../../test-data/influenza/influenza-A/H1N1PDM_California/H1N1PDM.sequences.tsv --cache {tmpfile_name}/mafft_influ --cols name=name collection_date=date country=location lineage=lineages sequences=sequences"
     code = run_cli(command)
 
     assert code == 0

--- a/apps/cli/tests/test_e2e_match.py
+++ b/apps/cli/tests/test_e2e_match.py
@@ -233,7 +233,7 @@ def test_match_prop_int_lt(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_length_exact(capfd, api_url):
     """Test exact length match"""
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --length 29676 --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3 --length 29676 --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     # Exact match should return samples with exactly 29676 bp length
@@ -244,7 +244,9 @@ def test_match_length_exact(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_length_range(capfd, api_url):
     """Test length range filter using colon separator (28000:29900)"""
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --length 28000:29900 --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --length 28000:29900 --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert code == 0
@@ -254,7 +256,9 @@ def test_match_length_range(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_length_lt(capfd, api_url):
     """Test length less than comparison"""
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --length '<30000' --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --length '<30000' --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert code == 0
@@ -265,7 +269,7 @@ def test_match_length_lt(capfd, api_url):
 def test_match_length_with_profile(capfd, api_url):
     """Test combining length filter with mutation profile"""
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --length 29000:29900 --profile G22992A --count"
+        f"sample match --db {api_url} -r MN908947.3 --length 29000:29900 --profile G22992A --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -276,7 +280,7 @@ def test_match_length_with_profile(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_float(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --euro 66.11 --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3 --euro 66.11 --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "1" == lines[-1]
@@ -285,7 +289,7 @@ def test_match_prop_float(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_float_not(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --euro '^66.11' --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3 --euro '^66.11' --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "17" == lines[-1]
@@ -294,7 +298,9 @@ def test_match_prop_float_not(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_float_range(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --euro '30:66.11' --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --euro '30:66.11' --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "6" == lines[-1]
@@ -303,7 +309,7 @@ def test_match_prop_float_range(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_float_gt(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --euro 31.16 --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3 --euro 31.16 --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "1" == lines[-1]
@@ -312,7 +318,7 @@ def test_match_prop_float_gt(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_float_lt(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --euro '<42.64' --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3 --euro '<42.64' --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "6" == lines[-1]
@@ -322,7 +328,7 @@ def test_match_prop_float_lt(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_date(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --collection_date 2022-01-30  --count"
+        f"sample match --db {api_url} -r MN908947.3 --collection_date 2022-01-30  --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -333,7 +339,7 @@ def test_match_prop_date(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_date_range(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --collection_date 2022-01-30:2022-06-30  --count"
+        f"sample match --db {api_url} -r MN908947.3 --collection_date 2022-01-30:2022-06-30  --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -343,7 +349,9 @@ def test_match_prop_date_range(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_zip(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --zip_code 16816  --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --zip_code 16816  --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "1" == lines[-1]
@@ -353,7 +361,9 @@ def test_match_prop_zip(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 @pytest.mark.order(13)
 def test_match_prop_zip_not(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --zip_code ^16816  --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --zip_code ^16816  --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "17" == lines[-1]
@@ -364,7 +374,7 @@ def test_match_prop_zip_not(capfd, api_url):
 def test_match_prop_complex_1(capfd, api_url):
     # combine AA and AA AND PROP
     code = run_cli(
-        f"match --db {api_url}  -r MN908947.3 --profile S:E484A S:N501Y --collection_date 2022-01-30 --count"
+        f"sample match --db {api_url}  -r MN908947.3 --profile S:E484A S:N501Y --collection_date 2022-01-30 --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -372,7 +382,7 @@ def test_match_prop_complex_1(capfd, api_url):
     assert code == 0
 
     code = run_cli(
-        f"match --db {api_url}  -r MN908947.3 --profile S:E484K S:N501Y --collection_date 2022-01-30 --count "
+        f"sample match --db {api_url}  -r MN908947.3 --profile S:E484K S:N501Y --collection_date 2022-01-30 --count "
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -384,7 +394,7 @@ def test_match_prop_complex_1(capfd, api_url):
 def test_match_prop_complex_2(capfd, api_url):
     # seach on given samples and get only samples that contain sequencing reason is N
     code = run_cli(
-        f"match --db {api_url} "
+        f"sample match --db {api_url} "
         "-r MN908947.3 "
         "--sample IMS-10150-CVDP-469B04EB-4D49-4109-9F81-0531CE275F6D "
         "IMS-10768-CVDP-0E69A26F-7AC0-4631-B0F3-192FF005FDA0 "
@@ -406,7 +416,7 @@ def skip_test_match_prop_complex_3():
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_complex_4(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --lineage BA.1 --profile C25584T --with-sublineage --count"
+        f"sample match --db {api_url} -r MN908947.3 --lineage BA.1 --profile C25584T --with-sublineage --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -417,7 +427,7 @@ def test_match_prop_complex_4(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_NT_DEL(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --profile del:21987-21995 --count"
+        f"sample match --db {api_url} -r MN908947.3 --profile del:21987-21995 --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -427,7 +437,9 @@ def test_match_profile_NT_DEL(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_AA_INS(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --profile S:R214REPE --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --profile S:R214REPE --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "2" == lines[-1]
@@ -438,7 +450,7 @@ def test_match_profile_AA_INS(capfd, api_url):
 @pytest.mark.order(14)
 def test_match_profile_AA_DEL(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --profile ORF1a:del:3675-3677 --count"
+        f"sample match --db {api_url} -r MN908947.3 --profile ORF1a:del:3675-3677 --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -449,7 +461,9 @@ def test_match_profile_AA_DEL(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 @pytest.mark.order(15)
 def test_match_profile_NT_DEL_single(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --profile del:28271 --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --profile del:28271 --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "5" == lines[-1]
@@ -458,7 +472,9 @@ def test_match_profile_NT_DEL_single(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_AA_DEL_single(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --profile S:del:157 --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --profile S:del:157 --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "2" == lines[-1]
@@ -467,7 +483,9 @@ def test_match_profile_AA_DEL_single(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_varchar_lineage(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --lineage BA.1.1 AY.4 --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --lineage BA.1.1 AY.4 --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "3" == lines[-1]
@@ -477,7 +495,7 @@ def test_match_prop_varchar_lineage(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_varchar_sublineage(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --lineage BA.1 --with-sublineage --count"
+        f"sample match --db {api_url} -r MN908947.3 --lineage BA.1 --with-sublineage --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -488,7 +506,9 @@ def test_match_prop_varchar_sublineage(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 @pytest.mark.order(16)
 def test_match_prop_varchar_not(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --sequencing_reason ^X --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --sequencing_reason ^X --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "12" == lines[-1]
@@ -497,7 +517,9 @@ def test_match_prop_varchar_not(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_varchar(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --sequencing_reason X  --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --sequencing_reason X  --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "5" == lines[-1]
@@ -507,7 +529,7 @@ def test_match_prop_varchar(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_anno_type(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --anno-type disruptive_inframe_insertion --count"
+        f"sample match --db {api_url} -r MN908947.3 --anno-type disruptive_inframe_insertion --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -518,7 +540,9 @@ def test_match_anno_type(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 @pytest.mark.order(17)
 def test_match_anno_impact(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --anno-impact HIGH --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --anno-impact HIGH --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     # assert "1" == lines[-1]
@@ -530,7 +554,7 @@ def test_match_anno_impact(capfd, api_url):
 @pytest.mark.order(18)
 def test_match_anno_impact_and_profile(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --anno-impact MODERATE --profile C24503T --count"
+        f"sample match --db {api_url} -r MN908947.3 --anno-impact MODERATE --profile C24503T --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -541,7 +565,7 @@ def test_match_anno_impact_and_profile(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_anno_impact_and_prop(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --anno-impact MODERATE  --age '>50' --count"
+        f"sample match --db {api_url} -r MN908947.3 --anno-impact MODERATE  --age '>50' --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -553,7 +577,7 @@ def test_match_anno_impact_and_prop(capfd, api_url):
 @pytest.mark.order(19)
 def test_match_anno_impact_and_type(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --anno-impact HIGH --anno-type stop_gained --count"
+        f"sample match --db {api_url} -r MN908947.3 --anno-impact HIGH --anno-type stop_gained --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -566,7 +590,7 @@ def test_match_anno_impact_and_type(capfd, api_url):
 @pytest.mark.xdist_group(name="rsv_group")
 @pytest.mark.order(4)
 def test_match_profile_count_rsv(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r OP975389.1  --count")
+    code = run_cli(f"sample match --db {api_url} -r OP975389.1  --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "20" == lines[-1]
@@ -576,7 +600,9 @@ def test_match_profile_count_rsv(capfd, api_url):
 @pytest.mark.xdist_group(name="rsv_group")
 @pytest.mark.order(5)
 def test_match_aa_mut_rsv(capfd, api_url):
-    code = run_cli(f"match --db {api_url}  -r OP975389.1 --profile SH:K53E --count")
+    code = run_cli(
+        f"sample match --db {api_url}  -r OP975389.1 --profile SH:K53E --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "1" == lines[-1]
@@ -587,7 +613,7 @@ def test_match_aa_mut_rsv(capfd, api_url):
 @pytest.mark.xdist_group(name="mpox_group")
 @pytest.mark.order(4)
 def test_match_profile_count_mpox(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r NC_063383.1  --count")
+    code = run_cli(f"sample match --db {api_url} -r NC_063383.1  --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "2" == lines[-1]
@@ -598,7 +624,7 @@ def test_match_profile_count_mpox(capfd, api_url):
 @pytest.mark.order(5)
 def test_match_aa_mut_mpox(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url}  -r NC_063383.1 --profile OPG136:D98L --count"
+        f"sample match --db {api_url}  -r NC_063383.1 --profile OPG136:D98L --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -610,7 +636,7 @@ def test_match_aa_mut_mpox(capfd, api_url):
 @pytest.mark.xdist_group(name="ebola_group")
 @pytest.mark.order(3)
 def test_match_profile_count_ebola(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r NC_002549.1  --count")
+    code = run_cli(f"sample match --db {api_url} -r NC_002549.1  --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "20" == lines[-1]
@@ -621,7 +647,7 @@ def test_match_profile_count_ebola(capfd, api_url):
 @pytest.mark.order(4)
 def test_match_aa_mut_ebola(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url}  -r NC_002549.1 --profile L:V1597A GP:K478R --count"
+        f"sample match --db {api_url}  -r NC_002549.1 --profile L:V1597A GP:K478R --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -633,7 +659,7 @@ def test_match_aa_mut_ebola(capfd, api_url):
 @pytest.mark.xdist_group(name="dengue_group")
 @pytest.mark.order(3)
 def test_match_profile_count_dengue(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r NC_001474.2 --count")
+    code = run_cli(f"sample match --db {api_url} -r NC_001474.2 --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "13" == lines[-1]
@@ -644,7 +670,9 @@ def test_match_profile_count_dengue(capfd, api_url):
 @pytest.mark.xdist_group(name="dengue_group")
 @pytest.mark.order(4)
 def test_match_aa_mut_dengue(capfd, api_url):
-    code = run_cli(f"match --db {api_url}  -r NC_001474.2 --profile POLY:N997S --count")
+    code = run_cli(
+        f"sample match --db {api_url}  -r NC_001474.2 --profile POLY:N997S --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "13" == lines[-1]
@@ -655,7 +683,7 @@ def test_match_aa_mut_dengue(capfd, api_url):
 @pytest.mark.xdist_group(name="hiv_group")
 @pytest.mark.order(3)
 def test_match_profile_count_hiv(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r NC_001802.1 --count")
+    code = run_cli(f"sample match --db {api_url} -r NC_001802.1 --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "20" == lines[-1]
@@ -666,7 +694,7 @@ def test_match_profile_count_hiv(capfd, api_url):
 @pytest.mark.order(3)
 def test_match_aa_mut_hiv(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url}  -r NC_001802.1 --profile env:Q344R nef:R29E --count"
+        f"sample match --db {api_url}  -r NC_001802.1 --profile env:Q344R nef:R29E --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -679,7 +707,7 @@ def test_match_aa_mut_hiv(capfd, api_url):
 def test_match_multiple_genes_in_same_region_hiv(capfd, api_url):
     # test mutations within 2 genes in same region: gene gag-pol (336..1637,1637..4642), gene gag: 336..1838,
     code = run_cli(
-        f"match --db {api_url}  -r NC_001802.1 --profile gag-pol:K424I gag:K424I --count"
+        f"sample match --db {api_url}  -r NC_001802.1 --profile gag-pol:K424I gag:K424I --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -687,7 +715,7 @@ def test_match_multiple_genes_in_same_region_hiv(capfd, api_url):
     assert code == 0
     # multiple genes in same region: gene gag-pol (336..1637,1637..4642), gene gag: 336..1838 different translation part
     code = run_cli(
-        f"match --db {api_url}  -r NC_001802.1 --profile gag-pol:L441P gag:Y441R --count"
+        f"sample match --db {api_url}  -r NC_001802.1 --profile gag-pol:L441P gag:Y441R --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -698,7 +726,9 @@ def test_match_multiple_genes_in_same_region_hiv(capfd, api_url):
 @pytest.mark.xdist_group(name="influ_group")
 @pytest.mark.order(3)
 def test_match_aa_influ(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r NC_026438.1 --profile HA:S220T --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r NC_026438.1 --profile HA:S220T --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
 
@@ -710,7 +740,7 @@ def test_match_aa_influ(capfd, api_url):
 @pytest.mark.order(4)
 def test_match_aa_2_influ(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r NC_026438.1 --profile CY121680.1:HA:S220T --count"
+        f"sample match --db {api_url} -r NC_026438.1 --profile CY121680.1:HA:S220T --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -723,7 +753,7 @@ def test_match_aa_2_influ(capfd, api_url):
 @pytest.mark.order(4)
 def test_match_nt_snp_influ(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r NC_026438.1 --profile NC_026435.1:C447G --count"
+        f"sample match --db {api_url} -r NC_026438.1 --profile NC_026435.1:C447G --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -736,7 +766,7 @@ def test_match_nt_snp_influ(capfd, api_url):
 @pytest.mark.order(4)
 def test_fail_match_nt_snp_influ(capfd, api_url):
     with pytest.raises(SystemExit) as e:
-        run_cli(f"match --db {api_url} -r NC_026438.1 --profile C447G --count")
+        run_cli(f"sample match --db {api_url} -r NC_026438.1 --profile C447G --count")
     out, err = capfd.readouterr()
     assert "Reference NC_026438.1 has 8 replicons" in err
     assert e.value.code == 1
@@ -746,7 +776,7 @@ def test_fail_match_nt_snp_influ(capfd, api_url):
 @pytest.mark.order(5)
 def test_match_nt_ins_influ(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r NC_026438.1 --profile NC_026435.1:A2274ATGAATTTAACTTGTCCTTCATGAAAAAATGCTTGTTTCTACTA --count"
+        f"sample match --db {api_url} -r NC_026438.1 --profile NC_026435.1:A2274ATGAATTTAACTTGTCCTTCATGAAAAAATGCTTGTTTCTACTA --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -759,7 +789,7 @@ def test_match_nt_ins_influ(capfd, api_url):
 @pytest.mark.order(6)
 def test_match_nt_del_influ(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r NC_026438.1 --profile CY121680.1:del:1722-1752 --count"
+        f"sample match --db {api_url} -r NC_026438.1 --profile CY121680.1:del:1722-1752 --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -772,7 +802,7 @@ def test_match_nt_del_influ(capfd, api_url):
 @pytest.mark.order(7)
 def test_match_profile_vcf_influenza(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r NC_026438.1  --sample A/swine/Miyazaki/344/2018  --format vcf"
+        f"sample match --db {api_url} -r NC_026438.1  --sample A/swine/Miyazaki/344/2018  --format vcf"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()

--- a/apps/cli/tests/test_e2e_match.py
+++ b/apps/cli/tests/test_e2e_match.py
@@ -5,17 +5,17 @@ from .conftest import run_cli_cmd
 
 
 def test_match(api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3")
     assert code == 0
 
 
 def test_match_pipe(capfd, api_url):
-    result = run_cli_cmd(f"sonar-cli match --db {api_url} -r MN908947.3 ")
+    result = run_cli_cmd(f"sonar-cli sample match --db {api_url} -r MN908947.3 ")
     assert result.returncode == 0, f"Expected exit code 0 but got {result}"
 
     # Check if the output contains the word "name"
     result = run_cli_cmd(
-        f"sonar-cli match --db {api_url} -r MN908947.3 --out-cols name | head -n 10"
+        f"sonar-cli sample match --db {api_url} -r MN908947.3 --out-cols name | head -n 10"
     )
     captured = capfd.readouterr()
     assert "name" in captured.out
@@ -28,7 +28,7 @@ def test_match_pipe(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 @pytest.mark.order(10)
 def test_match_profile_count_covid(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3  --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3  --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "18" == lines[-1]
@@ -37,7 +37,9 @@ def test_match_profile_count_covid(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_covid(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --profile G22992A --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --profile G22992A --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "9" == lines[-1]
@@ -47,7 +49,7 @@ def test_match_profile_covid(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_AND(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3  --profile T24469A C26858T --count"
+        f"sample match --db {api_url} -r MN908947.3  --profile T24469A C26858T --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -58,7 +60,7 @@ def test_match_profile_AND(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_OR(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --profile A1741G --profile G22992A --count"
+        f"sample match --db {api_url} -r MN908947.3 --profile A1741G --profile G22992A --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -68,7 +70,9 @@ def test_match_profile_OR(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_AA(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --profile S:T19R --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --profile S:T19R --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "2" == lines[-1]
@@ -79,7 +83,7 @@ def test_match_profile_AA(capfd, api_url):
 @pytest.mark.order(11)
 def test_match_profile_OR_AA(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --profile N:P13L --profile S:N501Y  --count"
+        f"sample match --db {api_url} -r MN908947.3 --profile N:P13L --profile S:N501Y  --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -89,7 +93,9 @@ def test_match_profile_OR_AA(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_showNX(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --profile S:T19R --showNX")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --profile S:T19R --showNX"
+    )
     out, err = capfd.readouterr()
     assert "A28213N" in out
     assert "ORF8:L118X" in out
@@ -98,7 +104,9 @@ def test_match_profile_showNX(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_exactN(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --profile A27624n --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --profile A27624n --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "2" == lines[-1]
@@ -108,7 +116,7 @@ def test_match_profile_exactN(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_vcf_covid(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --sample IMS-10013-CVDP-7629957A-D507-442D-BD2A-18236F7DB38C IMS-10150-CVDP-6EC46FD8-1FBA-427D-A559-411BCF94B679  --format vcf"
+        f"sample match --db {api_url} -r MN908947.3 --sample IMS-10013-CVDP-7629957A-D507-442D-BD2A-18236F7DB38C IMS-10150-CVDP-6EC46FD8-1FBA-427D-A559-411BCF94B679  --format vcf"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -118,7 +126,9 @@ def test_match_profile_vcf_covid(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_exactX(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --profile ORF7a:Q76x --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --profile ORF7a:Q76x --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "2" == lines[-1]
@@ -128,7 +138,7 @@ def test_match_profile_exactX(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_profile_NT_INS(capfd, api_url):
     code = run_cli(
-        f"match --db {api_url} -r MN908947.3 --profile A29903NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN --count"
+        f"sample match --db {api_url} -r MN908947.3 --profile A29903NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN --count"
     )
     out, err = capfd.readouterr()
     lines = out.splitlines()
@@ -138,7 +148,7 @@ def test_match_profile_NT_INS(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_varchar_NULL(capfd, api_url):
-    code = run_cli(f'match --db {api_url} -r MN908947.3 --lab "" --count')
+    code = run_cli(f'sample match --db {api_url} -r MN908947.3 --lab "" --count')
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "1" == lines[-1]
@@ -147,7 +157,7 @@ def test_match_varchar_NULL(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_varchar_widecard(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --lab %101% --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3 --lab %101% --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "5" == lines[-1]
@@ -156,7 +166,9 @@ def test_match_varchar_widecard(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_text(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --comments %mysteries% --count")
+    code = run_cli(
+        f"sample match --db {api_url} -r MN908947.3 --comments %mysteries% --count"
+    )
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "2" == lines[-1]
@@ -165,7 +177,7 @@ def test_match_prop_text(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_text_NULL(capfd, api_url):
-    code = run_cli(f'match --db {api_url} -r MN908947.3 --comments "" --count')
+    code = run_cli(f'sample match --db {api_url} -r MN908947.3 --comments "" --count')
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "0" == lines[-1]
@@ -174,7 +186,7 @@ def test_match_prop_text_NULL(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_int(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --age 16 --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3 --age 16 --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "1" == lines[-1]
@@ -184,7 +196,7 @@ def test_match_prop_int(capfd, api_url):
 @pytest.mark.xdist_group(name="covid_group")
 @pytest.mark.order(12)
 def test_match_prop_int_not(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --age ^16 --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3 --age ^16 --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "17" == lines[-1]
@@ -193,7 +205,7 @@ def test_match_prop_int_not(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_int_range(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --age 50:80 --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3 --age 50:80 --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "3" == lines[-1]
@@ -202,7 +214,7 @@ def test_match_prop_int_range(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_int_gt(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --age '>80' --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3 --age '>80' --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "6" == lines[-1]
@@ -211,7 +223,7 @@ def test_match_prop_int_gt(capfd, api_url):
 
 @pytest.mark.xdist_group(name="covid_group")
 def test_match_prop_int_lt(capfd, api_url):
-    code = run_cli(f"match --db {api_url} -r MN908947.3 --age '<70' --count")
+    code = run_cli(f"sample match --db {api_url} -r MN908947.3 --age '<70' --count")
     out, err = capfd.readouterr()
     lines = out.splitlines()
     assert "5" == lines[-1]

--- a/apps/cli/tests/test_failcase.py
+++ b/apps/cli/tests/test_failcase.py
@@ -8,7 +8,7 @@ from .conftest import run_cli
 
 def test_match_no_ref(capfd, api_url):
     with pytest.raises(SystemExit) as pytest_wrapped_e:
-        run_cli(f"match --db {api_url} -r NOREF")
+        run_cli(f"sample match --db {api_url} -r NOREF")
     out, err = capfd.readouterr()
     lines = err.splitlines()
     assert "reference NOREF does not exist" in lines[-1]
@@ -27,13 +27,13 @@ def test_add_duplicated_ref(monkeypatch, capfd, api_url):
     new_ref_file = "../../../test-data/HIV/NC_001802.1.gb"
 
     # Add the reference for the first time
-    code = run_cli(f"add-ref --db {api_url} --gb {new_ref_file}")
+    code = run_cli(f"reference add --db {api_url} --gb {new_ref_file}")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
 
     # Try to add the same reference again
-    code = run_cli(f"add-ref --db {api_url} --gb {new_ref_file}")
+    code = run_cli(f"reference add --db {api_url} --gb {new_ref_file}")
     out, err = capfd.readouterr()
     assert (
         "successfully." in err
@@ -41,7 +41,7 @@ def test_add_duplicated_ref(monkeypatch, capfd, api_url):
     assert code == 0
 
     # Cleanup: delete the reference
-    code = run_cli(f"delete-ref --db {api_url} -r NC_001802.1 --force")
+    code = run_cli(f"reference delete --db {api_url} -r NC_001802.1 --force")
     out, err = capfd.readouterr()
     assert "Reference deleted." in err
     assert code == 0
@@ -50,19 +50,19 @@ def test_add_duplicated_ref(monkeypatch, capfd, api_url):
 # add duplicated property
 def test_add_prop_int(capfd, api_url):
     code = run_cli(
-        f" add-prop --db {api_url} --name dup_integer --dtype value_integer --descr 'test-integer' "
+        f" property add --db {api_url} --name dup_integer --dtype value_integer --descr 'test-integer' "
     )
     out, err = capfd.readouterr()
     assert "Property added successfully" in err
     assert code == 0
     code = run_cli(
-        f" add-prop --db {api_url} --name dup_integer --dtype value_integer --descr 'test-integer' "
+        f" property add --db {api_url} --name dup_integer --dtype value_integer --descr 'test-integer' "
     )
     out, err = capfd.readouterr()
     assert "Property already exists" in err
     assert code == 0
 
-    code = run_cli(f"delete-prop --db {api_url} --name dup_integer --force ")
+    code = run_cli(f"property delete --db {api_url} --name dup_integer --force ")
     out, err = capfd.readouterr()
     assert "successfully" in err
     assert code == 0
@@ -70,14 +70,14 @@ def test_add_prop_int(capfd, api_url):
 
 # delete non existing property name
 def test_delete_fakeprop(capfd, api_url):
-    code = run_cli(f" delete-prop --db {api_url} --name fakePROP --force ")
+    code = run_cli(f" property delete --db {api_url} --name fakePROP --force ")
     out, err = capfd.readouterr()
     assert "No matching property found for deletion" in err
     assert code == 0
 
 
 def test_delete_sample(monkeypatch, capfd, api_url):
-    code = run_cli(f"delete-sample --db {api_url} --sample fake-id --force")
+    code = run_cli(f"sample delete --db {api_url} --sample fake-id --force")
     out, err = capfd.readouterr()
     assert "0 of 1 samples found and deleted." in err
     assert code == 0
@@ -85,7 +85,7 @@ def test_delete_sample(monkeypatch, capfd, api_url):
 
 # delete non existing sequence
 def test_delete_sequence(monkeypatch, capfd, api_url):
-    code = run_cli(f"delete-sequence --db {api_url} --sequence fake-id --force")
+    code = run_cli(f"sequence delete --db {api_url} --sequence fake-id --force")
     out, err = capfd.readouterr()
     print(out, err, code)
     assert "0 of 1 sequences found and deleted." in err
@@ -95,7 +95,7 @@ def test_delete_sequence(monkeypatch, capfd, api_url):
 # delete non existing reference
 def test_delete_noref(capfd, api_url):
     with pytest.raises(SystemExit) as pytest_wrapped_e:
-        run_cli(f"delete-ref --db {api_url} -r fakeREFID --force")
+        run_cli(f"reference delete --db {api_url} -r fakeREFID --force")
     out, err = capfd.readouterr()
     assert "The reference fakeREFID does not exist." in err
     assert pytest_wrapped_e.type == SystemExit
@@ -106,7 +106,9 @@ def test_delete_noref(capfd, api_url):
 def test_match_no_fasta(caplog, api_url):
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         with caplog.at_level(logging.ERROR):
-            run_cli(f"import --db {api_url} -r MN908947.3 --fasta where.is.my.fasta")
+            run_cli(
+                f"sample import --db {api_url} -r MN908947.3 --fasta where.is.my.fasta"
+            )
     assert "The file 'where.is.my.fasta' does not exist" in caplog.text
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1
@@ -115,7 +117,7 @@ def test_match_no_fasta(caplog, api_url):
 def test_match_no_tsv(caplog, api_url):
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         with caplog.at_level(logging.ERROR):
-            run_cli(f"import --db {api_url} -r MN908947.3 --tsv where.is.my.tsv")
+            run_cli(f"sample import --db {api_url} -r MN908947.3 --tsv where.is.my.tsv")
 
     assert "The file 'where.is.my.tsv' does not exist" in caplog.text
     assert pytest_wrapped_e.type == SystemExit
@@ -125,7 +127,7 @@ def test_match_no_tsv(caplog, api_url):
 def test_match_no_gb(caplog, api_url):
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         with caplog.at_level(logging.ERROR):
-            run_cli(f"add-ref --db {api_url} --gb where.is.gb.gb")
+            run_cli(f"reference add --db {api_url} --gb where.is.gb.gb")
     assert "The file 'where.is.gb.gb' does not exist" in caplog.text
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1

--- a/apps/cli/tests/test_job.py
+++ b/apps/cli/tests/test_job.py
@@ -2,14 +2,14 @@ from tests.conftest import run_cli
 
 
 def test_get_list_job(capfd, api_url):
-    code = run_cli(f" tasks --db {api_url} --list-jobs")
+    code = run_cli(f" task list --db {api_url}")
     out, err = capfd.readouterr()
     assert "Completed" in out
     assert code == 0
 
 
 def test_get_job_id(capfd, api_url):
-    code = run_cli(f" tasks --db {api_url} --jobid 'cli_failed-job'")
+    code = run_cli(f" task show --db {api_url} --jobid 'cli_failed-job'")
     out, err = capfd.readouterr()
     assert "Status: Failed" in out
     assert code == 0

--- a/apps/cli/tests/test_sonar.py
+++ b/apps/cli/tests/test_sonar.py
@@ -8,3 +8,20 @@ def test_no_args():
         sonar.main(None)
 
     assert pytest_wrapped_e.type == SystemExit
+
+
+def test_parse_subject_first_info():
+    args = sonar.parse_args(["info", "show", "--db", "http://cli.example/api"])
+    assert args.resource == "info"
+    assert args.verb == "show"
+
+
+def test_parse_subject_first_match():
+    args = sonar.parse_args(["sample", "match", "-r", "MN908947.3"])
+    assert args.resource == "sample"
+    assert args.verb == "match"
+
+
+def test_flat_command_is_rejected():
+    with pytest.raises(SystemExit):
+        sonar.parse_args(["list-ref"])

--- a/example-deploy/README.md
+++ b/example-deploy/README.md
@@ -160,7 +160,7 @@ cp sonar-cli.config "${XDG_CONFIG_HOME:-$HOME/.config}/sonar-cli/sonar-cli.confi
 Use the provided script:
 
 ```sh
-./sonar-cli.sh list-ref
+./sonar-cli.sh reference list
 ```
 
 `sonar-cli.sh`:
@@ -179,12 +179,12 @@ assumes a Linux host with Docker and `docker compose` available.
 ### Minimal SARS-CoV-2 Dataset
 
 ```sh
-./sonar-cli.sh add-ref --gb /data/sars-cov-2/MN908947.nextclade.gb
+./sonar-cli.sh reference add --gb /data/sars-cov-2/MN908947.nextclade.gb
 
 # Optional but useful for SARS-CoV-2 sublineage queries.
-./sonar-cli.sh import-lineage -l /data/sars-cov-2/lineages_test.tsv
+./sonar-cli.sh lineage import -l /data/sars-cov-2/lineages_test.tsv
 
-./sonar-cli.sh import \
+./sonar-cli.sh sample import \
   -r MN908947.3 \
   --auto-anno \
   --fasta /data/sars-cov-2/SARS-CoV-2_12.fasta.xz \
@@ -206,17 +206,17 @@ assumes a Linux host with Docker and `docker compose` available.
 Basic checks:
 
 ```sh
-./sonar-cli.sh list-ref
-./sonar-cli.sh info
-./sonar-cli.sh match -r MN908947.3 --count
+./sonar-cli.sh reference list
+./sonar-cli.sh info show
+./sonar-cli.sh sample match -r MN908947.3 --count
 ```
 
 ### Minimal Mpox Dataset
 
 ```sh
-./sonar-cli.sh add-ref --gb /data/mpox/clade-IIb-NC_063383.1.gb
+./sonar-cli.sh reference add --gb /data/mpox/clade-IIb-NC_063383.1.gb
 
-./sonar-cli.sh import \
+./sonar-cli.sh sample import \
   -r NC_063383.1 \
   --auto-anno \
   --fasta /data/mpox/mpox_2.fasta.xz \
@@ -227,9 +227,9 @@ Basic checks:
 Basic checks:
 
 ```sh
-./sonar-cli.sh list-ref
-./sonar-cli.sh info
-./sonar-cli.sh match -r NC_063383.1 --count
+./sonar-cli.sh reference list
+./sonar-cli.sh info show
+./sonar-cli.sh sample match -r NC_063383.1 --count
 ```
 
 ## Updating Images

--- a/example-deploy/bootstrap.sh
+++ b/example-deploy/bootstrap.sh
@@ -204,9 +204,9 @@ download_file \
   "data/mpox/mpox_2.tsv"
 
 echo "Running CLI example commands"
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh add-ref --gb /data/sars-cov-2/MN908947.nextclade.gb
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh import-lineage -l /data/sars-cov-2/lineages_test.tsv
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh import \
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh reference add --gb /data/sars-cov-2/MN908947.nextclade.gb
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh lineage import -l /data/sars-cov-2/lineages_test.tsv
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh sample import \
   -r MN908947.3 \
   --auto-anno \
   --fasta /data/sars-cov-2/SARS-CoV-2_12.fasta.xz \
@@ -223,20 +223,20 @@ SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh import \
   lab=lab \
   lineage=lineage \
   collection_date=collection_date
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh list-ref
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh info
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh match -r MN908947.3 --count
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh reference list
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh info show
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh sample match -r MN908947.3 --count
 
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh add-ref --gb /data/mpox/clade-IIb-NC_063383.1.gb
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh import \
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh reference add --gb /data/mpox/clade-IIb-NC_063383.1.gb
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh sample import \
   -r NC_063383.1 \
   --auto-anno \
   --fasta /data/mpox/mpox_2.fasta.xz \
   --tsv /data/mpox/mpox_2.tsv \
   --cols name=name
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh list-ref
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh info
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh match -r NC_063383.1 --count
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh reference list
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh info show
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh sample match -r NC_063383.1 --count
 
 echo
 echo "Bootstrap completed."

--- a/test-data/scripts/generate_fixture_data.sh
+++ b/test-data/scripts/generate_fixture_data.sh
@@ -21,12 +21,12 @@ cd ../cli
 source "$(conda info --base)/etc/profile.d/conda.sh"
 conda activate ./env
 
-sonar-cli add-ref --gb ../../test-data/sars-cov-2/MN908947.nextclade.gb
-sonar-cli import -r MN908947.3 --fasta "../../test-data/sars-cov-2/SARS-CoV-2_${SUFFIX}.fasta" --cache /sonar/data/import -t 7 --method 1  --auto-anno --no-skip --skip-nx
-sonar-cli add-prop --name sequencing_reason --descr "Sampling reason" --dtype value_varchar
-sonar-cli add-prop --name isolation_source --descr "Isolation Source" --dtype value_varchar
-sonar-cli import -r MN908947.3 -t 7 --tsv "../../test-data/sars-cov-2/SARS-CoV-2_${SUFFIX}.tsv" --cols name=igs_id sequencing_reason=sequencing_reason isolation_source=isolation_source collection_date=date_of_sampling sequencing_tech=sequencing_platform lab=sequencing_lab.demis_lab_id zip_code=prime_diagnostic_lab.postal_code lineage=lineages data_set=data_set
-sonar-cli import-lineage -l ../../test-data/sars-cov-2/lineages_test.tsv
+sonar-cli reference add --gb ../../test-data/sars-cov-2/MN908947.nextclade.gb
+sonar-cli sample import -r MN908947.3 --fasta "../../test-data/sars-cov-2/SARS-CoV-2_${SUFFIX}.fasta" --cache /sonar/data/import -t 7 --method 1  --auto-anno --no-skip --skip-nx
+sonar-cli property add --name sequencing_reason --descr "Sampling reason" --dtype value_varchar
+sonar-cli property add --name isolation_source --descr "Isolation Source" --dtype value_varchar
+sonar-cli sample import -r MN908947.3 -t 7 --tsv "../../test-data/sars-cov-2/SARS-CoV-2_${SUFFIX}.tsv" --cols name=igs_id sequencing_reason=sequencing_reason isolation_source=isolation_source collection_date=date_of_sampling sequencing_tech=sequencing_platform lab=sequencing_lab.demis_lab_id zip_code=prime_diagnostic_lab.postal_code lineage=lineages data_set=data_set
+sonar-cli lineage import -l ../../test-data/sars-cov-2/lineages_test.tsv
 
 rm "../../test-data/sars-cov-2/SARS-CoV-2_${SUFFIX}.tsv"
 rm "../../test-data/sars-cov-2/SARS-CoV-2_${SUFFIX}.fasta"

--- a/test-data/scripts/generate_test_sql_dump.sh
+++ b/test-data/scripts/generate_test_sql_dump.sh
@@ -12,19 +12,19 @@ cd ../cli
 source "$(conda info --base)/etc/profile.d/conda.sh"
 conda activate ./env
 
-sonar-cli add-ref --gb ../../test-data/sars-cov-2/MN908947.nextclade.gb
+sonar-cli reference add --gb ../../test-data/sars-cov-2/MN908947.nextclade.gb
 # import sequences
-sonar-cli import -r MN908947.3 --fasta ../../test-data/sars-cov-2/SARS-CoV-2_12.fasta -t 7 --method 1  --auto-anno --no-skip
+sonar-cli sample import -r MN908947.3 --fasta ../../test-data/sars-cov-2/SARS-CoV-2_12.fasta -t 7 --method 1  --auto-anno --no-skip
 # add properties to db
-sonar-cli add-prop --name age --descr "Age" --dtype value_integer
-sonar-cli add-prop --name sequencing_reason --descr "Sampling reason" --dtype value_varchar
-sonar-cli add-prop --name euro --descr "Price" --dtype value_float
-sonar-cli add-prop --name sample_type --descr "Sample Type" --dtype value_varchar
-sonar-cli add-prop --name comments --descr "Comments" --dtype value_varchar
+sonar-cli property add --name age --descr "Age" --dtype value_integer
+sonar-cli property add --name sequencing_reason --descr "Sampling reason" --dtype value_varchar
+sonar-cli property add --name euro --descr "Price" --dtype value_float
+sonar-cli property add --name sample_type --descr "Sample Type" --dtype value_varchar
+sonar-cli property add --name comments --descr "Comments" --dtype value_varchar
 # import sample properties
-sonar-cli import -r MN908947.3 -t 7 --tsv ../../test-data/sars-cov-2/SARS-CoV-2_12.tsv --cols name=name  collection_date=collection_date sequencing_tech=sequencing_tech lab=lab zip_code=zip_code lineage=lineage sample_type=sample_type comments=comments age=age euro=euro sequencing_reason=sequencing_reason
+sonar-cli sample import -r MN908947.3 -t 7 --tsv ../../test-data/sars-cov-2/SARS-CoV-2_12.tsv --cols name=name  collection_date=collection_date sequencing_tech=sequencing_tech lab=lab zip_code=zip_code lineage=lineage sample_type=sample_type comments=comments age=age euro=euro sequencing_reason=sequencing_reason
 # import lineages
-sonar-cli import-lineage -l ../../test-data/sars-cov-2/lineages_test.tsv
+sonar-cli lineage import -l ../../test-data/sars-cov-2/lineages_test.tsv
 
 cd ../backend
 # add to processing_job table: (job_name, status):


### PR DESCRIPTION
Until now, we've had a flat interface to the cli, with commands like `add-ref`, `import` and `match`. This change modifies the interface to use a subject-first structure, to focus on the main task of the cli: managing resources in the sonar database. So each command has subject (e.g. reference, sample, stats) and then a verb (e.g. import, add, remove). This has several advantages, including naturally grouping commands that operate on the same resources, making it easier to look up help on the cli (sonar reference --help for all commands related to references), and making it more clear what resources you are operating on with a given command.
