### PR TITLE
Change --gb to --genbank, fix behaviour when specifying --genbank multiple times (append, don't replace)

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -201,17 +201,17 @@ The table below shows the several commands that can be used.
 > [!TIP]
 > You can use `--db` to provide the URL to the backend (and it overwrites the configuration).
 >
-> for example, `sonar-cli reference add --db "http://127.0.0.1:8000/api" --gb test-data/sars-cov-2/MN908947.nextclade.gb`
+> for example, `sonar-cli reference add --db "http://127.0.0.1:8000/api" --genbank test-data/sars-cov-2/MN908947.nextclade.gb`
 >
 > for the `example-deploy` bundle, the corresponding default would be
-> `sonar-cli reference add --db "http://127.0.0.1:18000/api" --gb test-data/sars-cov-2/MN908947.nextclade.gb`
+> `sonar-cli reference add --db "http://127.0.0.1:18000/api" --genbank test-data/sars-cov-2/MN908947.nextclade.gb`
 
 ## Adding Reference
 
 The `reference add` subcommand is used to add reference genome sequences to the database.
 
 ```sh
-sonar-cli reference add --gb test-data/sars-cov-2/MN908947.nextclade.gb
+sonar-cli reference add --genbank test-data/sars-cov-2/MN908947.nextclade.gb
 ```
 
 ## Importing Genomes

--- a/apps/cli/src/sonar_cli/sonar.py
+++ b/apps/cli/src/sonar_cli/sonar.py
@@ -764,16 +764,18 @@ def create_subparser_add_reference(
         help="Adds reference genome to the database.",
     )
     parser.add_argument(
-        "--gb",
+        "--genbank",
         metavar="FILE",
         help=(
-            "Genbank file(s) of a reference genome. Normally, one genbank file per one reference genome, "
+            "GenBank file(s) of a reference genome. Normally, one GenBank file per one reference genome, "
             "however, in a case of a segmented genome (multiple genbank files), user can provide multiple files. "
-            "For example, --gb InfluenzaA_H1N1_seg1.gb InfluenzaA_H1N1_seg2.gb InfluenzaA_H1N1_seg7.gb ... "
+            "For example, --genbank InfluenzaA_H1N1_seg1.gb InfluenzaA_H1N1_seg2.gb InfluenzaA_H1N1_seg7.gb "
+            "or --genbank InfluenzaA_H1N1_seg1.gb --genbank InfluenzaA_H1N1_seg2.gb. "
             "This will automatically treat this import as a segmented genome, and the first file will be used as the "
             "index in the reference table and shown information in the reference list command."
         ),
         type=str,
+        action="extend",
         nargs="+",
         default=[],
         required=True,
@@ -1132,7 +1134,7 @@ def handle_list_ref(args: argparse.Namespace):
 
 
 def handle_add_ref(args: argparse.Namespace):
-    sonarUtils.add_ref_by_genebank_file(reference_gbs=args.gb)
+    sonarUtils.add_ref_by_genebank_file(reference_gbs=args.genbank)
 
 
 def handle_delete_ref(args: argparse.Namespace):

--- a/apps/cli/tests/test_e2e.py
+++ b/apps/cli/tests/test_e2e.py
@@ -160,7 +160,7 @@ def test_delete_prop_varchar(capfd, api_url):
 def test_add_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/influenza/H7N9/InfluA_H7N9_seg6.gb"
-    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --genbank {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0

--- a/apps/cli/tests/test_e2e_import.py
+++ b/apps/cli/tests/test_e2e_import.py
@@ -11,7 +11,7 @@ from .conftest import run_cli
 def test_add_cov19_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/sars-cov-2/MN908947.nextclade.gb"
-    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --genbank {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -22,7 +22,7 @@ def test_add_cov19_ref(monkeypatch, capfd, api_url):
 def test_add_mpox_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/mpox/clade-IIb-NC_063383.1.gb"
-    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --genbank {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -33,7 +33,7 @@ def test_add_mpox_ref(monkeypatch, capfd, api_url):
 def test_add_rsv_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/RSV/RSV-B/OP975389.1.gb"
-    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --genbank {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -44,7 +44,7 @@ def test_add_rsv_ref(monkeypatch, capfd, api_url):
 def test_add_measels_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/morbillivirus-hominis/NC_001498.gb"
-    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --genbank {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -55,7 +55,7 @@ def test_add_measels_ref(monkeypatch, capfd, api_url):
 def test_add_hiv_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/HIV/NC_001802.1.gb"
-    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --genbank {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -66,7 +66,7 @@ def test_add_hiv_ref(monkeypatch, capfd, api_url):
 def test_add_dengue_type2_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/dengue/type_2/NC_001474.2.gb"
-    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --genbank {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -77,7 +77,7 @@ def test_add_dengue_type2_ref(monkeypatch, capfd, api_url):
 def test_add_ebola_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/ebola/NC_002549.1.gb"
-    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --genbank {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -88,7 +88,7 @@ def test_add_ebola_ref(monkeypatch, capfd, api_url):
 def test_add_zika_ref(monkeypatch, capfd, api_url):
     monkeypatch.chdir(Path(__file__).parent)
     new_ref_file = "../../../test-data/zika/NC_035889.gb"
-    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --genbank {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
@@ -109,7 +109,7 @@ def test_add_influ_gbk(monkeypatch, capfd, api_url):
     new_ref_file += " ../../../test-data/influenza/influenza-A/H1N1PDM_California/segment_7_NC_026431.gb"
     new_ref_file += " ../../../test-data/influenza/influenza-A/H1N1PDM_California/segment_8_NC_026432.1.gb"
 
-    code = run_cli(f" reference add --db {api_url} --gb {new_ref_file} ")
+    code = run_cli(f" reference add --db {api_url} --genbank {new_ref_file} ")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0

--- a/apps/cli/tests/test_failcase.py
+++ b/apps/cli/tests/test_failcase.py
@@ -27,13 +27,13 @@ def test_add_duplicated_ref(monkeypatch, capfd, api_url):
     new_ref_file = "../../../test-data/HIV/NC_001802.1.gb"
 
     # Add the reference for the first time
-    code = run_cli(f"reference add --db {api_url} --gb {new_ref_file}")
+    code = run_cli(f"reference add --db {api_url} --genbank {new_ref_file}")
     out, err = capfd.readouterr()
     assert "successfully." in err
     assert code == 0
 
     # Try to add the same reference again
-    code = run_cli(f"reference add --db {api_url} --gb {new_ref_file}")
+    code = run_cli(f"reference add --db {api_url} --genbank {new_ref_file}")
     out, err = capfd.readouterr()
     assert (
         "successfully." in err
@@ -127,7 +127,7 @@ def test_match_no_tsv(caplog, api_url):
 def test_match_no_gb(caplog, api_url):
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         with caplog.at_level(logging.ERROR):
-            run_cli(f"reference add --db {api_url} --gb where.is.gb.gb")
+            run_cli(f"reference add --db {api_url} --genbank where.is.gb.gb")
     assert "The file 'where.is.gb.gb' does not exist" in caplog.text
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 1

--- a/apps/cli/tests/test_sonar.py
+++ b/apps/cli/tests/test_sonar.py
@@ -22,6 +22,40 @@ def test_parse_subject_first_match():
     assert args.verb == "match"
 
 
+def test_parse_reference_add_genbank_accepts_multiple_files_in_one_flag():
+    args = sonar.parse_args(
+        [
+            "reference",
+            "add",
+            "--genbank",
+            "seq1.gb",
+            "seq2.gb",
+            "seq3.gb",
+        ]
+    )
+
+    assert args.resource == "reference"
+    assert args.verb == "add"
+    assert args.genbank == ["seq1.gb", "seq2.gb", "seq3.gb"]
+
+
+def test_parse_reference_add_genbank_accepts_repeated_flags():
+    args = sonar.parse_args(
+        [
+            "reference",
+            "add",
+            "--genbank",
+            "seq1.gb",
+            "--genbank",
+            "seq2.gb",
+            "--genbank",
+            "seq3.gb",
+        ]
+    )
+
+    assert args.genbank == ["seq1.gb", "seq2.gb", "seq3.gb"]
+
+
 def test_flat_command_is_rejected():
     with pytest.raises(SystemExit):
         sonar.parse_args(["list-ref"])

--- a/example-deploy/README.md
+++ b/example-deploy/README.md
@@ -179,7 +179,7 @@ assumes a Linux host with Docker and `docker compose` available.
 ### Minimal SARS-CoV-2 Dataset
 
 ```sh
-./sonar-cli.sh reference add --gb /data/sars-cov-2/MN908947.nextclade.gb
+./sonar-cli.sh reference add --genbank /data/sars-cov-2/MN908947.nextclade.gb
 
 # Optional but useful for SARS-CoV-2 sublineage queries.
 ./sonar-cli.sh lineage import -l /data/sars-cov-2/lineages_test.tsv
@@ -214,7 +214,7 @@ Basic checks:
 ### Minimal Mpox Dataset
 
 ```sh
-./sonar-cli.sh reference add --gb /data/mpox/clade-IIb-NC_063383.1.gb
+./sonar-cli.sh reference add --genbank /data/mpox/clade-IIb-NC_063383.1.gb
 
 ./sonar-cli.sh sample import \
   -r NC_063383.1 \

--- a/example-deploy/bootstrap.sh
+++ b/example-deploy/bootstrap.sh
@@ -204,7 +204,7 @@ download_file \
   "data/mpox/mpox_2.tsv"
 
 echo "Running CLI example commands"
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh reference add --gb /data/sars-cov-2/MN908947.nextclade.gb
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh reference add --genbank /data/sars-cov-2/MN908947.nextclade.gb
 SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh lineage import -l /data/sars-cov-2/lineages_test.tsv
 SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh sample import \
   -r MN908947.3 \
@@ -227,7 +227,7 @@ SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh reference list
 SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh info show
 SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh sample match -r MN908947.3 --count
 
-SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh reference add --gb /data/mpox/clade-IIb-NC_063383.1.gb
+SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh reference add --genbank /data/mpox/clade-IIb-NC_063383.1.gb
 SONAR_CLI_IMAGE="$SONAR_CLI_IMAGE" ./sonar-cli.sh sample import \
   -r NC_063383.1 \
   --auto-anno \

--- a/test-data/scripts/generate_fixture_data.sh
+++ b/test-data/scripts/generate_fixture_data.sh
@@ -21,7 +21,7 @@ cd ../cli
 source "$(conda info --base)/etc/profile.d/conda.sh"
 conda activate ./env
 
-sonar-cli reference add --gb ../../test-data/sars-cov-2/MN908947.nextclade.gb
+sonar-cli reference add --genbank ../../test-data/sars-cov-2/MN908947.nextclade.gb
 sonar-cli sample import -r MN908947.3 --fasta "../../test-data/sars-cov-2/SARS-CoV-2_${SUFFIX}.fasta" --cache /sonar/data/import -t 7 --method 1  --auto-anno --no-skip --skip-nx
 sonar-cli property add --name sequencing_reason --descr "Sampling reason" --dtype value_varchar
 sonar-cli property add --name isolation_source --descr "Isolation Source" --dtype value_varchar

--- a/test-data/scripts/generate_test_sql_dump.sh
+++ b/test-data/scripts/generate_test_sql_dump.sh
@@ -12,7 +12,7 @@ cd ../cli
 source "$(conda info --base)/etc/profile.d/conda.sh"
 conda activate ./env
 
-sonar-cli reference add --gb ../../test-data/sars-cov-2/MN908947.nextclade.gb
+sonar-cli reference add --genbank ../../test-data/sars-cov-2/MN908947.nextclade.gb
 # import sequences
 sonar-cli sample import -r MN908947.3 --fasta ../../test-data/sars-cov-2/SARS-CoV-2_12.fasta -t 7 --method 1  --auto-anno --no-skip
 # add properties to db


### PR DESCRIPTION
The old documentation showed adding multi-segment references like this: sonar-cli reference add --gb r1.gb --gb r2.gb --gb r3.gb. This would actually have a different outcome as expected, since the artument parser would only keep the last genbank file and ignore the others. This PR changes the behaviour to appending the genbank files, while also supporting the more typical usage: add --gb r1.gb r2.gb r3.gb. I also changed --gb to --genbank to be more explicit.
