### PR TITLE
Fix problem with correct version not being picked up when running GitHub actions, leading to a failure

### DIFF
--- a/.github/workflows/frontend-playwright.yml
+++ b/.github/workflows/frontend-playwright.yml
@@ -2,6 +2,8 @@ name: Frontend E2E Playwright Tests
 on:
   pull_request:
     paths:
+      - 'VERSION'
+      - 'scripts/sync-version.py'
       - 'apps/backend/**'
       - 'apps/frontend/**'
   workflow_dispatch:
@@ -16,6 +18,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
+      - name: Check synchronized versions
+        run: python scripts/sync-version.py --check
       - uses: actions/setup-node@v6
         with:
           node-version: lts/*
@@ -40,7 +44,9 @@ jobs:
         run: ./node_modules/.bin/playwright install firefox
       - name: Set backend API url
         working-directory: ./apps/frontend
-        run: echo "VITE_SONAR_BACKEND_ADDRESS=\"${SONAR_LOCAL_API_URL}\"" >> .env.production.local
+        run: |
+          echo "VITE_SONAR_BACKEND_ADDRESS=\"${SONAR_LOCAL_API_URL}\"" >> .env.production.local
+          echo "VITE_SONAR_VERSION=\"$(cat ../../VERSION)\"" >> .env.production.local
       - name: Build frontend
         working-directory: ./apps/frontend
         run: npm run build:backend-proxy

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -2,6 +2,8 @@ name: frontend test build
 on:
   pull_request:
     paths:
+      - 'VERSION'
+      - 'scripts/sync-version.py'
       - 'apps/frontend/**'
   workflow_dispatch:
 jobs:
@@ -15,6 +17,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
+      - name: Check synchronized versions
+        working-directory: .
+        run: python scripts/sync-version.py --check
       - name: Install
         run: npm ci
       - name: Run eslint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,28 +63,35 @@ For normal source changes, update the root `VERSION` file when the product
 version should change. Local builds read this file when no build-time version is
 provided.
 
+After changing `VERSION`, synchronize component package metadata:
+
+```sh
+python scripts/sync-version.py
+```
+
 For releases, use a pull request for the version bump. Do not push directly to
 `main`.
 
 1. Create a release branch from the latest `main`.
 2. Update `VERSION` to the release version, for example `1.2.3`.
-3. Open a pull request for the version bump and wait for the required checks.
-4. Merge the pull request into `main`.
-5. Update your local `main` to the merged commit:
+3. Run `python scripts/sync-version.py`.
+4. Open a pull request for the version bump and wait for the required checks.
+5. Merge the pull request into `main`.
+6. Update your local `main` to the merged commit:
 
    ```sh
    git switch main
    git pull --ff-only origin main
    ```
 
-6. Create a Git tag on the merged `main` commit with the same version and a
+7. Create a Git tag on the merged `main` commit with the same version and a
    leading `v`, for example:
 
    ```sh
    git tag v1.2.3
    ```
 
-7. Push the tag:
+8. Push the tag:
 
    ```sh
    git push origin v1.2.3

--- a/apps/backend/compose.yml
+++ b/apps/backend/compose.yml
@@ -180,6 +180,8 @@ services:
     build:
       context: ../frontend
       dockerfile: Dockerfile
+      args:
+        SONAR_VERSION: ${SONAR_VERSION:-}
     image: frontend:local
     restart: unless-stopped
     environment:

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sonar-backend"
-version = "1.0.3"
+version = "1.0.4"
 description = ""
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"

--- a/apps/backend/scripts/linux/clean-dev-env.sh
+++ b/apps/backend/scripts/linux/clean-dev-env.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+REPO_ROOT="$(cd "$SCRIPTPATH/../../../.." && pwd)"
+export SONAR_VERSION="${SONAR_VERSION:-$(tr -d '[:space:]' < "$REPO_ROOT/VERSION")}"
 
 # Default to adding test data and also rebuilding the docker container
 DELETE=1

--- a/apps/cli/pyproject.toml
+++ b/apps/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sonar-cli"
-version = "1.0.3"
+version = "1.0.4"
 description = "Sonar command line tool to interface with the sonar-backend and PostgreSQL version."
 authors = ["Stephan Fuchs <FuchsS@rki.de>", "Kunaphas Kongkitimanon <KongkitimanonK@hpi.de>", "Juliane Schmachtenberg <anna-juliane.schmachtenberg@hpi.de>", "Simeon Schmachtenberg", "Matthew Huska <HuskaM@rki.de>"]
 license = "AGPL-3.0-only"

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sonar-frontend",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sonar-frontend",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "axios": "^1.16.0",
         "chart.js": "^4.4.3",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonar-frontend",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/scripts/sync-version.py
+++ b/scripts/sync-version.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+VERSION = (ROOT / "VERSION").read_text(encoding="utf-8").strip()
+FILES = [
+    ROOT / "apps/frontend/package.json",
+    ROOT / "apps/frontend/package-lock.json",
+    ROOT / "apps/cli/pyproject.toml",
+    ROOT / "apps/backend/pyproject.toml",
+]
+
+
+def sync_json_version(path: Path) -> bool:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    changed = data.get("version") != VERSION
+    data["version"] = VERSION
+    if "packages" in data and "" in data["packages"]:
+        changed = changed or data["packages"][""].get("version") != VERSION
+        data["packages"][""]["version"] = VERSION
+    if changed:
+        path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    return changed
+
+
+def sync_poetry_version(path: Path) -> bool:
+    content = path.read_text(encoding="utf-8")
+    updated = re.sub(
+        r'(?m)^version = "[^"]+"$',
+        f'version = "{VERSION}"',
+        content,
+        count=1,
+    )
+    if updated != content:
+        path.write_text(updated, encoding="utf-8")
+        return True
+    return False
+
+
+def json_version_matches(path: Path) -> bool:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("version") != VERSION:
+        return False
+    if "packages" in data and "" in data["packages"]:
+        return data["packages"][""].get("version") == VERSION
+    return True
+
+
+def poetry_version_matches(path: Path) -> bool:
+    content = path.read_text(encoding="utf-8")
+    match = re.search(r'(?m)^version = "([^"]+)"$', content)
+    return bool(match and match.group(1) == VERSION)
+
+
+def check_versions() -> list[Path]:
+    mismatched = []
+    for path in FILES[:2]:
+        if not json_version_matches(path):
+            mismatched.append(path)
+    for path in FILES[2:]:
+        if not poetry_version_matches(path):
+            mismatched.append(path)
+    return mismatched
+
+
+def sync_versions() -> list[Path]:
+    changed = []
+    for path in FILES[:2]:
+        if sync_json_version(path):
+            changed.append(path)
+    for path in FILES[2:]:
+        if sync_poetry_version(path):
+            changed.append(path)
+    return changed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Synchronize component package metadata with root VERSION."
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if component package metadata is not synchronized.",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        mismatched = check_versions()
+        if mismatched:
+            print("Component metadata is not synchronized with VERSION.")
+            for path in mismatched:
+                print(f"Out of sync: {path.relative_to(ROOT)}")
+            print("Run: python scripts/sync-version.py")
+            return 1
+        print(f"Component metadata is synchronized to {VERSION}")
+        return 0
+
+    changed = sync_versions()
+    if changed:
+        print(f"Synchronized component metadata to {VERSION}")
+    else:
+        print(f"Component metadata already synchronized to {VERSION}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
We tried to have all versioning centralized to the root's "VERSION" file. This works in most cases but I found a few situations where the old versions that are written to the various project json files are picked up instead. This PR aims to resolve that problem by both writing the version number from VERSION into the apps' package files, and also by trying harder to use the VERSION file contents when building each app.
