### PR TITLE
Make clean-dev-env.sh script more robust and easier to debug

### DIFF
--- a/apps/backend/scripts/linux/clean-dev-env.sh
+++ b/apps/backend/scripts/linux/clean-dev-env.sh
@@ -63,6 +63,14 @@ if [ $REBUILD -eq 0 ]; then
   DC_ARGS="--build"
 fi
 
+mkdir -p \
+  ./work/sonar/data/import/gbks \
+  ./work/sonar/data/processing \
+  ./work/sonar/data/archive \
+  ./work/sonar/logs \
+  ./work/sonar/input-logs \
+  ./work/sonar/coverage
+
 $SCRIPTPATH/dc-dev.sh up --wait -d $DC_ARGS
 
 if [ $TEST_DATA -eq 0 ]; then

--- a/apps/backend/scripts/linux/dev-copy-gbk.sh
+++ b/apps/backend/scripts/linux/dev-copy-gbk.sh
@@ -1,19 +1,21 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # Check if the correct number of arguments is provided
 if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 <source_file> <destination_repo>"
+  echo "Usage: $0 <source_file> <destination_repo>" >&2
   exit 1
 fi
 
 SOURCE_FILE="$1"
 DEST_REPO="$2"
 
+if [ ! -f "$SOURCE_FILE" ]; then
+  echo "Source file does not exist: $SOURCE_FILE" >&2
+  exit 1
+fi
+
 # Copy the file to the destination repository
 mkdir -p "$DEST_REPO"
 cp "$SOURCE_FILE" "$DEST_REPO"
-
-# Check if the copy was successful
-if ! [ $? -eq 0 ]; then
-  echo "Failed to copy file to $DEST_REPO"
-fi


### PR DESCRIPTION
The current script has intermittent problems with permissions between inside and outside of the containers. This lead to some problems with GitHub actions failing. The solution here is mainly to address those action failures, I'll have to look into whether it's a problem for e.g. the example deployment scripts/bundle.
