### PR TITLE
Increase dependency checks with dependabot and on PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,41 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+  - package-ecosystem: "pip"
+    directory: "/apps/cli"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      cli-python:
+        applies-to: version-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/apps/frontend"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      frontend-npm:
+        applies-to: version-updates
+        patterns:
+          - "*"
+  - package-ecosystem: "docker"
+    directory: "/apps/backend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/apps/cli"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/apps/frontend"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,14 @@
+name: 'Dependency Review'
+on: [pull_request]
+permissions:
+  contents: read
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v6
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v5
+        with:
+          fail-on-severity: moderate


### PR DESCRIPTION
Have dependabot do more checks, and also check dependencies of PRs. This is to keep track of known vulternabilities and also to avoid introducing known vulternabilities into the repo.
