### PR TITLE
[codex] Avoid Redis pubsub result waits during imports

### DIFF
--- a/apps/backend/rest_api/data_entry/sample_entry_job.py
+++ b/apps/backend/rest_api/data_entry/sample_entry_job.py
@@ -1,12 +1,16 @@
+from collections import Counter
 from datetime import datetime
 import pathlib
 import pickle
 import shutil
+import time
+from time import perf_counter
 import traceback
 import zipfile
 
 from celery import group
 from celery import shared_task
+from celery import states
 from django.core.cache import cache
 from django.core.exceptions import FieldDoesNotExist
 from django.db import DataError
@@ -42,6 +46,75 @@ from sonar_backend.settings import SONAR_DATA_ENTRY_FOLDER
 from sonar_backend.settings import SONAR_DATA_PROCESSING_FOLDER
 
 property_cache = {}
+
+
+def _collect_celery_group_results(
+    group_result,
+    *,
+    task_label="import",
+    poll_interval_seconds=0.5,
+    progress_interval_seconds=30,
+):
+    """Collect Celery group results without Redis result-backend pubsub."""
+    async_results = list(group_result.results)
+    pending_results = {
+        async_result.id: (index, async_result)
+        for index, async_result in enumerate(async_results)
+    }
+    results = [None] * len(pending_results)
+    completed_count = 0
+    total_count = len(pending_results)
+    last_progress = perf_counter()
+
+    try:
+        while pending_results:
+            completed_task_ids = []
+            status_counts = Counter()
+            for task_id, (index, async_result) in pending_results.items():
+                meta = async_result.backend.get_task_meta(task_id)
+                status = meta.get("status")
+                status_counts[status] += 1
+                if status not in states.READY_STATES:
+                    continue
+
+                if status in states.PROPAGATE_STATES:
+                    result = meta.get("result")
+                    if isinstance(result, BaseException):
+                        raise result
+                    raise RuntimeError(
+                        f"Celery {task_label} task {task_id} failed: {result}"
+                    )
+
+                results[index] = meta.get("result")
+                completed_task_ids.append(task_id)
+
+            for task_id in completed_task_ids:
+                _, async_result = pending_results.pop(task_id)
+                async_result.forget()
+
+            if completed_task_ids:
+                completed_count += len(completed_task_ids)
+            now = perf_counter()
+            if now - last_progress >= progress_interval_seconds:
+                LOGGER.info(
+                    "Waiting for %s Celery tasks: %s/%s complete; pending statuses: %s",
+                    task_label,
+                    completed_count,
+                    total_count,
+                    dict(status_counts),
+                )
+                last_progress = now
+            if pending_results:
+                time.sleep(poll_interval_seconds)
+    finally:
+        try:
+            group_result.forget()
+        except Exception as exc:
+            LOGGER.warning(
+                "Could not forget Celery %s group result: %s", task_label, exc
+            )
+
+    return results
 
 
 def check_for_new_data():
@@ -227,16 +300,20 @@ def import_archive(process_file_path: pathlib.Path, pkl_path: pathlib.Path = Non
                                 str(temp_dir),
                             )
                         )
-                    results = group(sample_jobs).apply_async().get()
+                    results = _collect_celery_group_results(
+                        group(sample_jobs).apply_async(),
+                        task_label="sample import",
+                    )
                     for result in results:
                         if not result[0]:
                             raise Exception(
                                 f"Sample Import Error: {result[1]} - {result[2]}"
                             )
-                    results = (
-                        group([process_annotation.s(str(file)) for file in anno_files])
-                        .apply_async()
-                        .get()
+                    results = _collect_celery_group_results(
+                        group(
+                            [process_annotation.s(str(file)) for file in anno_files]
+                        ).apply_async(),
+                        task_label="annotation import",
                     )
                     for result in results:
                         if not result[0]:
@@ -725,7 +802,10 @@ def import_property(
                 )
 
             # Run the Celery group of tasks and collect results
-            results = group(property_jobs).apply_async().get()
+            results = _collect_celery_group_results(
+                group(property_jobs).apply_async(),
+                task_label="property import",
+            )
 
             for result in results:
                 if not result[0]:

--- a/apps/backend/rest_api/test/test_data_entry/test_sample_entry_job.py
+++ b/apps/backend/rest_api/test/test_data_entry/test_sample_entry_job.py
@@ -1,0 +1,108 @@
+from unittest import mock
+from unittest import TestCase
+
+from celery import states
+
+from rest_api.data_entry.sample_entry_job import _collect_celery_group_results
+
+
+class FakeAsyncResult:
+    def __init__(self, task_id, backend):
+        self.id = task_id
+        self.backend = backend
+        self.forget = mock.Mock()
+
+
+class FakeBackend:
+    """Stands in for the Celery/Redis backend: get_task_meta() reads
+    whatever state the test put in `metas`, no Redis involved."""
+
+    def __init__(self, metas):
+        self.metas = metas
+
+    def get_task_meta(self, task_id):
+        return self.metas[task_id]
+
+
+class FakeGroupResult:
+    def __init__(self, async_results):
+        self.results = async_results
+        self.forget = mock.Mock()
+
+
+def make_group(count, backend):
+    return FakeGroupResult(
+        [FakeAsyncResult(f"task-{i}", backend) for i in range(count)]
+    )
+
+
+class CollectCeleryGroupResultsTest(TestCase):
+    def test_all_success_preserves_order_and_forgets_everything(self):
+        backend = FakeBackend(
+            {
+                "task-0": {"status": states.SUCCESS, "result": (True, "a", 0)},
+                "task-1": {"status": states.SUCCESS, "result": (True, "b", 1)},
+                "task-2": {"status": states.SUCCESS, "result": (True, "c", 2)},
+            }
+        )
+        group_result = make_group(3, backend)
+
+        results = _collect_celery_group_results(group_result)
+
+        self.assertEqual(
+            results,
+            [(True, "a", 0), (True, "b", 1), (True, "c", 2)],
+        )
+        for async_result in group_result.results:
+            async_result.forget.assert_called_once()
+        group_result.forget.assert_called_once()
+
+    def test_failure_reraises_original_exception_and_still_forgets_group(self):
+        error = ValueError("boom")
+        backend = FakeBackend(
+            {
+                "task-0": {"status": states.SUCCESS, "result": (True, "a", 0)},
+                "task-1": {"status": states.FAILURE, "result": error},
+            }
+        )
+        group_result = make_group(2, backend)
+
+        with self.assertRaises(ValueError):
+            _collect_celery_group_results(group_result)
+
+        # cleanup must still happen even though we raised
+        group_result.forget.assert_called_once()
+
+    def test_non_exception_failure_result_raises_runtime_error(self):
+        backend = FakeBackend(
+            {"task-0": {"status": states.FAILURE, "result": "disk full"}}
+        )
+        group_result = make_group(1, backend)
+
+        with self.assertRaisesRegex(RuntimeError, "disk full"):
+            _collect_celery_group_results(group_result)
+
+    def test_empty_group_returns_empty_list(self):
+        backend = FakeBackend({})
+        group_result = make_group(0, backend)
+
+        results = _collect_celery_group_results(group_result)
+
+        self.assertEqual(results, [])
+        group_result.forget.assert_called_once()
+
+    @mock.patch("rest_api.data_entry.sample_entry_job.time.sleep")
+    def test_pending_task_is_polled_until_ready(self, mock_sleep):
+        metas = {"task-0": {"status": states.PENDING, "result": None}}
+        backend = FakeBackend(metas)
+        group_result = make_group(1, backend)
+
+        def flip_to_success(*_args, **_kwargs):
+            metas["task-0"] = {"status": states.SUCCESS, "result": (True, "done")}
+
+        mock_sleep.side_effect = flip_to_success
+
+        results = _collect_celery_group_results(group_result, poll_interval_seconds=0)
+
+        self.assertEqual(results, [(True, "done")])
+        mock_sleep.assert_called_once()


### PR DESCRIPTION
## Summary

- Replace Celery `GroupResult.get()` waits in import paths with explicit task metadata polling.
- Forget completed task and group results after collection.
- Preserve existing task result ordering and failure propagation.

## Why

The Redis result backend pubsub path can hit `ConnectionPool.get_connection()` compatibility failures during large imports. Polling task metadata avoids that pubsub subscription path while keeping the Celery/Redis import flow.

## Validation

- `python -m py_compile apps/backend/rest_api/data_entry/sample_entry_job.py`
- pre-commit hooks on commit