### PR TITLE
[codex] Reduce sample import mutation construction overhead

### DIFF
--- a/apps/backend/rest_api/data_entry/sample_entry_job.py
+++ b/apps/backend/rest_api/data_entry/sample_entry_job.py
@@ -285,7 +285,6 @@ def import_archive(process_file_path: pathlib.Path, pkl_path: pathlib.Path = Non
             if batch_size:
                 replicon_cache = {}
                 gene_cache_by_accession = {}
-                gene_cache_by_var_pos = {}
                 if REDIS_URL:
                     print("setting up sample import celery jobs..")
                     sample_jobs = []
@@ -296,7 +295,6 @@ def import_archive(process_file_path: pathlib.Path, pkl_path: pathlib.Path = Non
                                 batch,
                                 replicon_cache,
                                 gene_cache_by_accession,
-                                gene_cache_by_var_pos,
                                 str(temp_dir),
                             )
                         )
@@ -334,7 +332,6 @@ def import_archive(process_file_path: pathlib.Path, pkl_path: pathlib.Path = Non
                             batch,
                             replicon_cache,
                             gene_cache_by_accession,
-                            gene_cache_by_var_pos,
                             str(temp_dir),
                         )
                     # annotation
@@ -427,7 +424,6 @@ def process_batch(
     batch: list[str],
     replicon_cache,
     gene_cache_by_accession,
-    gene_cache_by_var_pos,
     temp_dir,
 ):
     parameters = locals().copy()
@@ -451,7 +447,6 @@ def process_batch_run(
     batch: list[str],
     replicon_cache,
     gene_cache_by_accession,
-    gene_cache_by_var_pos,
     temp_dir,
 ):
     try:
@@ -486,7 +481,9 @@ def process_batch_run(
             )
 
         nt_mutation_set: list[NucleotideMutation] = []
+        nt_mutation_lookup: dict[tuple, NucleotideMutation] = {}
         cds_mutation_set: list[AminoAcidMutation] = []
+        cds_mutation_lookup: dict[tuple, AminoAcidMutation] = {}
         mutation_parent_relations = []
         nt_mutation_alignment_relations: list[NucleotideMutation.alignments.through] = (
             []
@@ -495,13 +492,14 @@ def process_batch_run(
         for sample_import_obj in sonar_import_objs:
             id_to_mutation_mapping = sample_import_obj.get_mutation_objs_nt(
                 nt_mutation_set,
+                nt_mutation_lookup,
                 replicon_cache,
-                gene_cache_by_var_pos,
                 nt_mutation_alignment_relations,
             )
             parent_relations = (
                 sample_import_obj.get_mutation_objs_cds_and_parent_relations(
                     cds_mutation_set,
+                    cds_mutation_lookup,
                     gene_cache_by_accession,
                     id_to_mutation_mapping,
                     aa_mutation_alignment_relations,
@@ -589,7 +587,7 @@ def process_annotation(file_name):
 
 
 def process_batch_single_thread(
-    batch, replicon_cache, gene_cache_by_accession, gene_cache_by_var_pos, temp_dir
+    batch, replicon_cache, gene_cache_by_accession, temp_dir
 ):
     try:
         sample_import_objs = [
@@ -621,7 +619,9 @@ def process_batch_single_thread(
                 update_fields=["sequence", "replicon"],
             )
             nt_mutation_set: list[NucleotideMutation] = []
+            nt_mutation_lookup: dict[tuple, NucleotideMutation] = {}
             cds_mutation_set: list[AminoAcidMutation] = []
+            cds_mutation_lookup: dict[tuple, AminoAcidMutation] = {}
             mutation_parent_relations = []
             nt_mutation_alignment_relations: list[
                 NucleotideMutation.alignments.through
@@ -633,13 +633,14 @@ def process_batch_single_thread(
             for sample_import_obj in sample_import_objs:
                 id_to_mutation_mapping = sample_import_obj.get_mutation_objs_nt(
                     nt_mutation_set,
+                    nt_mutation_lookup,
                     replicon_cache,
-                    gene_cache_by_var_pos,
                     nt_mutation_alignment_relations,
                 )
                 parent_relations = (
                     sample_import_obj.get_mutation_objs_cds_and_parent_relations(
                         cds_mutation_set,
+                        cds_mutation_lookup,
                         gene_cache_by_accession,
                         id_to_mutation_mapping,
                         aa_mutation_alignment_relations,

--- a/apps/backend/rest_api/data_entry/sample_import.py
+++ b/apps/backend/rest_api/data_entry/sample_import.py
@@ -11,7 +11,6 @@ import pandas as pd
 from rest_api.models import Alignment
 from rest_api.models import AminoAcidMutation
 from rest_api.models import CDS
-from rest_api.models import Gene
 from rest_api.models import NucleotideMutation
 from rest_api.models import Replicon
 from rest_api.models import Sample
@@ -140,8 +139,8 @@ class SonarImport:
     def get_mutation_objs_nt(
         self,
         nt_mutation_set: list[NucleotideMutation],
+        nt_mutation_lookup: dict[tuple, NucleotideMutation],
         replicon_cache: dict[str, Replicon | None],
-        gene_cache_by_var_pos: dict[Replicon | None, dict[int, dict[int, Gene | None]]],
         nt_mutation_alignment_relations: list[NucleotideMutation.alignments.through],
     ) -> dict[int, NucleotideMutation]:
         import_id_to_sample_mutations: dict[int, NucleotideMutation] = {}
@@ -155,19 +154,6 @@ class SonarImport:
                         )
                     )
                 replicon = replicon_cache[var_raw.replicon_or_cds_accession]
-                if not replicon in gene_cache_by_var_pos:
-                    gene_cache_by_var_pos[replicon] = {}
-                if not var_raw.start in gene_cache_by_var_pos[replicon]:
-                    gene_cache_by_var_pos[replicon][var_raw.start] = {}
-                if not var_raw.end in gene_cache_by_var_pos[replicon][var_raw.start]:
-                    gene_cache_by_var_pos[replicon][var_raw.start][var_raw.end] = (
-                        Gene.objects.filter(
-                            replicon=replicon,
-                            start__gte=var_raw.start,
-                            end__lte=var_raw.end,
-                        ).first()
-                    )
-                gene = gene_cache_by_var_pos[replicon][var_raw.start][var_raw.end]
                 # in DEL, we dont keep REF in the database.
                 if var_raw.alt is None:
                     var_raw.ref = ""
@@ -180,15 +166,18 @@ class SonarImport:
                     "replicon": self.replicon,
                     "is_frameshift": var_raw.frameshift,
                 }
-                mutation = next(
-                    filter(
-                        lambda x: self.is_same_mutation(mutation_data, x),
-                        nt_mutation_set,
-                    ),
-                    None,
+                mutation_key = (
+                    mutation_data["ref"],
+                    mutation_data["alt"],
+                    mutation_data["start"],
+                    mutation_data["end"],
+                    mutation_data["replicon"].pk if mutation_data["replicon"] else None,
+                    mutation_data["is_frameshift"],
                 )
+                mutation = nt_mutation_lookup.get(mutation_key)
                 if not mutation:
                     mutation = NucleotideMutation(**mutation_data)
+                    nt_mutation_lookup[mutation_key] = mutation
                     nt_mutation_set.append(mutation)
                 nt_mutation_alignment_relations.append(
                     NucleotideMutation.alignments.through(
@@ -206,6 +195,7 @@ class SonarImport:
     def get_mutation_objs_cds_and_parent_relations(
         self,
         cds_mutation_set: list[AminoAcidMutation],
+        cds_mutation_lookup: dict[tuple, AminoAcidMutation],
         gene_cache_by_accession: dict[str, CDS | None],
         parent_id_mapping: dict[int, NucleotideMutation],
         aa_mutation_alignment_relations: list[AminoAcidMutation.alignments.through],
@@ -234,15 +224,17 @@ class SonarImport:
                     "start": var_raw.start if var_raw.start else 0,
                     "end": var_raw.end if var_raw.end else 0,
                 }
-                mutation = next(
-                    filter(
-                        lambda x: self.is_same_mutation(mutation_data, x),
-                        cds_mutation_set,
-                    ),
-                    None,
+                mutation_key = (
+                    mutation_data["cds"].pk if mutation_data["cds"] else None,
+                    mutation_data["ref"],
+                    mutation_data["alt"],
+                    mutation_data["start"],
+                    mutation_data["end"],
                 )
+                mutation = cds_mutation_lookup.get(mutation_key)
                 if not mutation:
                     mutation = AminoAcidMutation(**mutation_data)
+                    cds_mutation_lookup[mutation_key] = mutation
                     cds_mutation_set.append(mutation)
                 aa_mutation_alignment_relations.append(
                     AminoAcidMutation.alignments.through(


### PR DESCRIPTION
## Summary

- Remove the unused per-nucleotide-mutation `Gene` lookup from sample imports.
- Replace linear scans for existing NT/CDS mutation objects with per-batch dictionary lookups.
- Keep the same bulk create/update behavior and mutation relation construction.

## Why

Large imports were doing repeated lookup work while constructing mutation objects. The removed `Gene` lookup did not feed persisted mutation data, and linear de-duplication became increasingly expensive within each batch.

## Validation

- `python -m py_compile apps/backend/rest_api/data_entry/sample_import.py apps/backend/rest_api/data_entry/sample_entry_job.py`
- pre-commit hooks on commit