### PR TITLE
[codex] Reduce backend sample import runtime

### DIFF
--- a/apps/backend/rest_api/data_entry/sample_entry_job.py
+++ b/apps/backend/rest_api/data_entry/sample_entry_job.py
@@ -285,7 +285,6 @@ def import_archive(process_file_path: pathlib.Path, pkl_path: pathlib.Path = Non
             if batch_size:
                 replicon_cache = {}
                 gene_cache_by_accession = {}
-                gene_cache_by_var_pos = {}
                 if REDIS_URL:
                     print("setting up sample import celery jobs..")
                     sample_jobs = []
@@ -296,7 +295,6 @@ def import_archive(process_file_path: pathlib.Path, pkl_path: pathlib.Path = Non
                                 batch,
                                 replicon_cache,
                                 gene_cache_by_accession,
-                                gene_cache_by_var_pos,
                                 str(temp_dir),
                             )
                         )
@@ -334,7 +332,6 @@ def import_archive(process_file_path: pathlib.Path, pkl_path: pathlib.Path = Non
                             batch,
                             replicon_cache,
                             gene_cache_by_accession,
-                            gene_cache_by_var_pos,
                             str(temp_dir),
                         )
                     # annotation
@@ -427,7 +424,6 @@ def process_batch(
     batch: list[str],
     replicon_cache,
     gene_cache_by_accession,
-    gene_cache_by_var_pos,
     temp_dir,
 ):
     parameters = locals().copy()
@@ -451,7 +447,6 @@ def process_batch_run(
     batch: list[str],
     replicon_cache,
     gene_cache_by_accession,
-    gene_cache_by_var_pos,
     temp_dir,
 ):
     try:
@@ -486,7 +481,9 @@ def process_batch_run(
             )
 
         nt_mutation_set: list[NucleotideMutation] = []
+        nt_mutation_lookup: dict[tuple, NucleotideMutation] = {}
         cds_mutation_set: list[AminoAcidMutation] = []
+        cds_mutation_lookup: dict[tuple, AminoAcidMutation] = {}
         mutation_parent_relations = []
         nt_mutation_alignment_relations: list[NucleotideMutation.alignments.through] = (
             []
@@ -495,13 +492,14 @@ def process_batch_run(
         for sample_import_obj in sonar_import_objs:
             id_to_mutation_mapping = sample_import_obj.get_mutation_objs_nt(
                 nt_mutation_set,
+                nt_mutation_lookup,
                 replicon_cache,
-                gene_cache_by_var_pos,
                 nt_mutation_alignment_relations,
             )
             parent_relations = (
                 sample_import_obj.get_mutation_objs_cds_and_parent_relations(
                     cds_mutation_set,
+                    cds_mutation_lookup,
                     gene_cache_by_accession,
                     id_to_mutation_mapping,
                     aa_mutation_alignment_relations,
@@ -589,7 +587,7 @@ def process_annotation(file_name):
 
 
 def process_batch_single_thread(
-    batch, replicon_cache, gene_cache_by_accession, gene_cache_by_var_pos, temp_dir
+    batch, replicon_cache, gene_cache_by_accession, temp_dir
 ):
     try:
         sample_import_objs = [
@@ -621,7 +619,9 @@ def process_batch_single_thread(
                 update_fields=["sequence", "replicon"],
             )
             nt_mutation_set: list[NucleotideMutation] = []
+            nt_mutation_lookup: dict[tuple, NucleotideMutation] = {}
             cds_mutation_set: list[AminoAcidMutation] = []
+            cds_mutation_lookup: dict[tuple, AminoAcidMutation] = {}
             mutation_parent_relations = []
             nt_mutation_alignment_relations: list[
                 NucleotideMutation.alignments.through
@@ -633,13 +633,14 @@ def process_batch_single_thread(
             for sample_import_obj in sample_import_objs:
                 id_to_mutation_mapping = sample_import_obj.get_mutation_objs_nt(
                     nt_mutation_set,
+                    nt_mutation_lookup,
                     replicon_cache,
-                    gene_cache_by_var_pos,
                     nt_mutation_alignment_relations,
                 )
                 parent_relations = (
                     sample_import_obj.get_mutation_objs_cds_and_parent_relations(
                         cds_mutation_set,
+                        cds_mutation_lookup,
                         gene_cache_by_accession,
                         id_to_mutation_mapping,
                         aa_mutation_alignment_relations,

--- a/apps/backend/rest_api/data_entry/sample_entry_job.py
+++ b/apps/backend/rest_api/data_entry/sample_entry_job.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from collections import defaultdict
 from datetime import datetime
 import pathlib
 import pickle
@@ -23,6 +24,8 @@ import pandas as pd
 from rest_api import models
 from rest_api.data_entry.annotation_import import AnnotationImport
 from rest_api.data_entry.sample_import import SonarImport
+from rest_api.data_entry.sample_import import VAR_BATCH_SAMPLE_COLUMN
+from rest_api.data_entry.sample_import import VAR_PARQUET_COLUMNS
 from rest_api.models import Alignment
 from rest_api.models import AminoAcidMutation
 from rest_api.models import AnnotationType
@@ -46,6 +49,50 @@ from sonar_backend.settings import SONAR_DATA_ENTRY_FOLDER
 from sonar_backend.settings import SONAR_DATA_PROCESSING_FOLDER
 
 property_cache = {}
+
+
+def _load_sample_raw_by_file(batch: list[str]):
+    sample_raw_by_file = {}
+    for file in batch:
+        if pathlib.Path(file).suffix == ".samplebatch":
+            sample_batch = SonarImport.import_pickle(file)
+            for index, sample_raw in enumerate(sample_batch):
+                sample_raw_by_file[f"{file}::{index}"] = sample_raw
+        else:
+            sample_raw_by_file[file] = SonarImport.import_pickle(file)
+    return sample_raw_by_file
+
+
+def _load_variant_batch_rows_by_sample_file(
+    sample_raw_by_file: dict[str, dict],
+    temp_dir,
+):
+    var_batch_files = sorted(
+        {
+            sample_raw.get("var_batch_file")
+            for sample_raw in sample_raw_by_file.values()
+            if sample_raw.get("var_batch_file")
+        }
+    )
+    if not var_batch_files:
+        return {}
+
+    sample_file_by_name = {
+        sample_raw.get("var_batch_sample_name") or sample_raw["name"]: sample_file
+        for sample_file, sample_raw in sample_raw_by_file.items()
+        if sample_raw.get("var_batch_file")
+    }
+    rows_by_sample_file = defaultdict(list)
+    for var_batch_file in var_batch_files:
+        variant_batch_df = pd.read_parquet(
+            pathlib.Path(temp_dir).joinpath(var_batch_file),
+            columns=[VAR_BATCH_SAMPLE_COLUMN, *VAR_PARQUET_COLUMNS],
+        )
+        for row in variant_batch_df.itertuples(index=False, name=None):
+            sample_file = sample_file_by_name.get(row[0])
+            if sample_file:
+                rows_by_sample_file[sample_file].append(row[1:])
+    return rows_by_sample_file
 
 
 def _collect_celery_group_results(
@@ -261,11 +308,15 @@ def import_archive(process_file_path: pathlib.Path, pkl_path: pathlib.Path = Non
             batch_size = SAMPLE_BATCH_SIZE
             print("Batch size:", batch_size)
             # var and vcf
-            sample_files = list(temp_dir.joinpath("samples").glob("**/*.sample"))
+            sample_batch_files = sorted(
+                temp_dir.joinpath("sample_batches").glob("**/*.samplebatch")
+            )
+            sample_files = sorted(temp_dir.joinpath("samples").glob("**/*.sample"))
             anno_files = list(temp_dir.joinpath("anno").glob("**/*.vcf.*"))
             print(f"Sample: {len(sample_files)} files found")
+            print(f"Sample batches: {len(sample_batch_files)} files found")
             print(f"Annotation (vcfs): {len(anno_files)} files found")
-            if len(sample_files) > 0:
+            if len(sample_batch_files) > 0 or len(sample_files) > 0:
                 import_type = ImportLog.ImportType.SAMPLE
             elif len(anno_files) > 0:
                 import_type = ImportLog.ImportType.ANNOTATION
@@ -274,22 +325,32 @@ def import_archive(process_file_path: pathlib.Path, pkl_path: pathlib.Path = Non
 
             timer = datetime.now()
 
-            number_of_batches = (
-                (len(sample_files) + batch_size - 1) // batch_size
-                if sample_files
-                else (len(anno_files) + batch_size - 1) // batch_size
-            )
+            if sample_batch_files:
+                sample_work_items = [str(file) for file in sample_batch_files]
+                number_of_batches = len(sample_work_items)
+            else:
+                sample_work_items = [str(file) for file in sample_files]
+                number_of_batches = (
+                    (len(sample_work_items) + batch_size - 1) // batch_size
+                    if sample_work_items
+                    else (len(anno_files) + batch_size - 1) // batch_size
+                )
 
             print(f"Total number of batches: {number_of_batches}")
-            sample_files = [str(file) for file in sample_files]
             if batch_size:
                 replicon_cache = {}
                 gene_cache_by_accession = {}
                 if REDIS_URL:
                     print("setting up sample import celery jobs..")
                     sample_jobs = []
-                    for i in range(0, len(sample_files), batch_size):
-                        batch = sample_files[i : i + batch_size]
+                    if sample_batch_files:
+                        sample_batches = [[file] for file in sample_work_items]
+                    else:
+                        sample_batches = [
+                            sample_work_items[i : i + batch_size]
+                            for i in range(0, len(sample_work_items), batch_size)
+                        ]
+                    for batch in sample_batches:
                         sample_jobs.append(
                             process_batch.s(
                                 batch,
@@ -322,12 +383,18 @@ def import_archive(process_file_path: pathlib.Path, pkl_path: pathlib.Path = Non
                     replicon_cache = {}
                     gene_cache_by_accession = {}
                     # Samples
-                    for i in range(0, len(sample_files), batch_size):
+                    if sample_batch_files:
+                        sample_batches = [[file] for file in sample_work_items]
+                    else:
+                        sample_batches = [
+                            sample_work_items[i : i + batch_size]
+                            for i in range(0, len(sample_work_items), batch_size)
+                        ]
+                    for batch in sample_batches:
                         # print(
                         #     f"processing batch {(i//batch_size) + 1} of {number_of_batches}"
                         # )
                         # batchtimer = datetime.now()
-                        batch = sample_files[i : i + batch_size]
                         process_batch_single_thread(
                             batch,
                             replicon_cache,
@@ -450,8 +517,19 @@ def process_batch_run(
     temp_dir,
 ):
     try:
+        sample_raw_by_file = _load_sample_raw_by_file(batch)
+        variant_rows_by_file = _load_variant_batch_rows_by_sample_file(
+            sample_raw_by_file,
+            temp_dir,
+        )
         sonar_import_objs = [
-            SonarImport(pathlib.Path(file), import_folder=temp_dir) for file in batch
+            SonarImport(
+                pathlib.Path(file),
+                import_folder=temp_dir,
+                sample_raw_data=sample_raw_by_file[file],
+                variant_rows=variant_rows_by_file.get(file),
+            )
+            for file in sample_raw_by_file
         ]
         sequences = [
             sample_import_obj.get_sequence_obj()
@@ -590,8 +668,19 @@ def process_batch_single_thread(
     batch, replicon_cache, gene_cache_by_accession, temp_dir
 ):
     try:
+        sample_raw_by_file = _load_sample_raw_by_file(batch)
+        variant_rows_by_file = _load_variant_batch_rows_by_sample_file(
+            sample_raw_by_file,
+            temp_dir,
+        )
         sample_import_objs = [
-            SonarImport(file, import_folder=temp_dir) for file in batch
+            SonarImport(
+                pathlib.Path(file),
+                import_folder=temp_dir,
+                sample_raw_data=sample_raw_by_file[file],
+                variant_rows=variant_rows_by_file.get(file),
+            )
+            for file in sample_raw_by_file
         ]
         with transaction.atomic():
             sequences = [

--- a/apps/backend/rest_api/data_entry/sample_entry_job.py
+++ b/apps/backend/rest_api/data_entry/sample_entry_job.py
@@ -1,12 +1,16 @@
+from collections import Counter
 from datetime import datetime
 import pathlib
 import pickle
 import shutil
+import time
+from time import perf_counter
 import traceback
 import zipfile
 
 from celery import group
 from celery import shared_task
+from celery import states
 from django.core.cache import cache
 from django.core.exceptions import FieldDoesNotExist
 from django.db import DataError
@@ -42,6 +46,75 @@ from sonar_backend.settings import SONAR_DATA_ENTRY_FOLDER
 from sonar_backend.settings import SONAR_DATA_PROCESSING_FOLDER
 
 property_cache = {}
+
+
+def _collect_celery_group_results(
+    group_result,
+    *,
+    task_label="import",
+    poll_interval_seconds=0.5,
+    progress_interval_seconds=30,
+):
+    """Collect Celery group results without Redis result-backend pubsub."""
+    async_results = list(group_result.results)
+    pending_results = {
+        async_result.id: (index, async_result)
+        for index, async_result in enumerate(async_results)
+    }
+    results = [None] * len(pending_results)
+    completed_count = 0
+    total_count = len(pending_results)
+    last_progress = perf_counter()
+
+    try:
+        while pending_results:
+            completed_task_ids = []
+            status_counts = Counter()
+            for task_id, (index, async_result) in pending_results.items():
+                meta = async_result.backend.get_task_meta(task_id)
+                status = meta.get("status")
+                status_counts[status] += 1
+                if status not in states.READY_STATES:
+                    continue
+
+                if status in states.PROPAGATE_STATES:
+                    result = meta.get("result")
+                    if isinstance(result, BaseException):
+                        raise result
+                    raise RuntimeError(
+                        f"Celery {task_label} task {task_id} failed: {result}"
+                    )
+
+                results[index] = meta.get("result")
+                completed_task_ids.append(task_id)
+
+            for task_id in completed_task_ids:
+                _, async_result = pending_results.pop(task_id)
+                async_result.forget()
+
+            if completed_task_ids:
+                completed_count += len(completed_task_ids)
+            now = perf_counter()
+            if now - last_progress >= progress_interval_seconds:
+                LOGGER.info(
+                    "Waiting for %s Celery tasks: %s/%s complete; pending statuses: %s",
+                    task_label,
+                    completed_count,
+                    total_count,
+                    dict(status_counts),
+                )
+                last_progress = now
+            if pending_results:
+                time.sleep(poll_interval_seconds)
+    finally:
+        try:
+            group_result.forget()
+        except Exception as exc:
+            LOGGER.warning(
+                "Could not forget Celery %s group result: %s", task_label, exc
+            )
+
+    return results
 
 
 def check_for_new_data():
@@ -227,16 +300,20 @@ def import_archive(process_file_path: pathlib.Path, pkl_path: pathlib.Path = Non
                                 str(temp_dir),
                             )
                         )
-                    results = group(sample_jobs).apply_async().get()
+                    results = _collect_celery_group_results(
+                        group(sample_jobs).apply_async(),
+                        task_label="sample import",
+                    )
                     for result in results:
                         if not result[0]:
                             raise Exception(
                                 f"Sample Import Error: {result[1]} - {result[2]}"
                             )
-                    results = (
-                        group([process_annotation.s(str(file)) for file in anno_files])
-                        .apply_async()
-                        .get()
+                    results = _collect_celery_group_results(
+                        group(
+                            [process_annotation.s(str(file)) for file in anno_files]
+                        ).apply_async(),
+                        task_label="annotation import",
                     )
                     for result in results:
                         if not result[0]:
@@ -725,7 +802,10 @@ def import_property(
                 )
 
             # Run the Celery group of tasks and collect results
-            results = group(property_jobs).apply_async().get()
+            results = _collect_celery_group_results(
+                group(property_jobs).apply_async(),
+                task_label="property import",
+            )
 
             for result in results:
                 if not result[0]:

--- a/apps/backend/rest_api/data_entry/sample_import.py
+++ b/apps/backend/rest_api/data_entry/sample_import.py
@@ -35,6 +35,8 @@ class SampleRaw:
     translationid: int
     include_nx: bool
     var_parquet_file: Optional[str] = None
+    var_batch_file: Optional[str] = None
+    var_batch_sample_name: Optional[str] = None
     vcffile: Optional[str] = None
     algnid: Optional[int] = None
     sequenceid: Optional[int] = None
@@ -70,6 +72,7 @@ VAR_PARQUET_COLUMNS = [
     "frameshift",
     "parent_id",
 ]
+VAR_BATCH_SAMPLE_COLUMN = "sample_name"
 
 
 class VCFInfoLOFRaw:
@@ -93,19 +96,34 @@ class SonarImport:
         self,
         path: pathlib.Path,
         import_folder="import_data",
+        sample_raw_data: dict | None = None,
+        variant_rows=None,
     ):
         self.sample_file_path = path
         self.import_folder = import_folder
-        self.sample_raw = SampleRaw(**self._import_pickle(path))
+        if sample_raw_data is None:
+            sample_raw_data = self._import_pickle(path)
+        self.sample_raw = SampleRaw(**sample_raw_data)
         self.sequence: None | Sequence = None
         self.sample: None | Sample = None
         self.replicon: None | Replicon = None
         self.alignment: None | Alignment = None
         self.success = False
 
-        if self.sample_raw.var_parquet_file:
+        if variant_rows is not None:
+            self.vars_raw = self._import_vars_from_rows(
+                variant_rows,
+                self.sample_raw.include_nx,
+            )
+        elif self.sample_raw.var_parquet_file:
             self.vars_raw = self._import_vars(
                 self.sample_raw.var_parquet_file, self.sample_raw.include_nx
+            )
+        elif self.sample_raw.var_batch_file:
+            self.vars_raw = self._import_vars_from_batch(
+                self.sample_raw.var_batch_file,
+                self.sample_raw.include_nx,
+                self.sample_raw.var_batch_sample_name or self.sample_raw.name,
             )
         else:
             raise Exception("No var file found")
@@ -277,6 +295,11 @@ class SonarImport:
         with open(path, "rb") as f:
             return pickle.load(f)
 
+    @staticmethod
+    def import_pickle(path: str):
+        with open(path, "rb") as f:
+            return pickle.load(f)
+
     def _parse_parent_ids(self, parent_id) -> list[int] | None:
         if pd.notna(parent_id) and parent_id.strip() != "":
             return [int(x) for x in parent_id.split(",")]
@@ -297,6 +320,33 @@ class SonarImport:
         )
         var_df = pd.read_parquet(self.var_file_path, columns=VAR_PARQUET_COLUMNS)
 
+        return self._import_vars_from_rows(
+            var_df.itertuples(index=False, name=None),
+            include_nx,
+        )
+
+    def _import_vars_from_batch(
+        self,
+        path,
+        include_nx: bool,
+        sample_name: str,
+    ):
+        self.var_file_path = pathlib.Path(self.import_folder).joinpath(path)
+        var_df = pd.read_parquet(
+            self.var_file_path,
+            columns=[VAR_BATCH_SAMPLE_COLUMN, *VAR_PARQUET_COLUMNS],
+        )
+
+        return self._import_vars_from_rows(
+            (
+                row[1:]
+                for row in var_df.itertuples(index=False, name=None)
+                if row[0] == sample_name
+            ),
+            include_nx,
+        )
+
+    def _import_vars_from_rows(self, variant_rows, include_nx: bool):
         variants = []
         for (
             var_id,
@@ -308,7 +358,7 @@ class SonarImport:
             var_type,
             frameshift,
             parent_id,
-        ) in var_df.itertuples(index=False, name=None):
+        ) in variant_rows:
             try:
                 ref = self._clean_variant_base(ref)
                 alt = self._clean_variant_base(alt)

--- a/apps/backend/rest_api/data_entry/sample_import.py
+++ b/apps/backend/rest_api/data_entry/sample_import.py
@@ -59,6 +59,19 @@ class VarRaw:
     parent_id: list[int] | None
 
 
+VAR_PARQUET_COLUMNS = [
+    "id",
+    "ref",
+    "start",
+    "end",
+    "alt",
+    "reference_acc",
+    "type",
+    "frameshift",
+    "parent_id",
+]
+
+
 class VCFInfoLOFRaw:
     # Predicted loss of function effects for this variant.
     gene_name: str
@@ -91,12 +104,9 @@ class SonarImport:
         self.success = False
 
         if self.sample_raw.var_parquet_file:
-            self.vars_raw = [
-                var
-                for var in self._import_vars(
-                    self.sample_raw.var_parquet_file, self.sample_raw.include_nx
-                )
-            ]
+            self.vars_raw = self._import_vars(
+                self.sample_raw.var_parquet_file, self.sample_raw.include_nx
+            )
         else:
             raise Exception("No var file found")
 
@@ -267,6 +277,16 @@ class SonarImport:
         with open(path, "rb") as f:
             return pickle.load(f)
 
+    def _parse_parent_ids(self, parent_id) -> list[int] | None:
+        if pd.notna(parent_id) and parent_id.strip() != "":
+            return [int(x) for x in parent_id.split(",")]
+        return None
+
+    def _clean_variant_base(self, value):
+        if pd.isna(value) or value == " ":
+            return ""
+        return value
+
     def _import_vars(self, path, include_nx: bool):
         file_name = pathlib.Path(path).name
         self.var_file_path = (
@@ -275,38 +295,49 @@ class SonarImport:
             .joinpath(file_name[:2])
             .joinpath(file_name)
         )
-        var_df = pd.read_parquet(self.var_file_path)
-        var_df[["ref", "alt"]] = var_df[["ref", "alt"]].fillna("").replace({" ": ""})
+        var_df = pd.read_parquet(self.var_file_path, columns=VAR_PARQUET_COLUMNS)
 
-        if not include_nx:
-            # remove all ref containing Ns for nt, or X for cds
-            var_df = var_df[
-                ~((var_df["type"] == "nt") & var_df["alt"].str.contains("N", na=False))
-            ]
-            var_df = var_df[
-                ~((var_df["type"] == "cds") & var_df["alt"].str.contains("X", na=False))
-            ]
-        for _, row in var_df.iterrows():
+        variants = []
+        for (
+            var_id,
+            ref,
+            start,
+            end,
+            alt,
+            reference_acc,
+            var_type,
+            frameshift,
+            parent_id,
+        ) in var_df.itertuples(index=False, name=None):
             try:
-                yield VarRaw(
-                    row["id"],
-                    row["ref"],
-                    row["start"],
-                    row["end"],
-                    row["alt"],
-                    row["reference_acc"],
-                    row["type"],
-                    row["frameshift"],
-                    (
-                        [int(x) for x in row["parent_id"].split(",")]
-                        if pd.notna(row["parent_id"]) and row["parent_id"].strip() != ""
-                        else None
+                ref = self._clean_variant_base(ref)
+                alt = self._clean_variant_base(alt)
+                if not include_nx and (
+                    (var_type == "nt" and "N" in alt)
+                    or (var_type == "cds" and "X" in alt)
+                ):
+                    continue
+                variants.append(
+                    VarRaw(
+                        var_id,
+                        ref,
+                        start,
+                        end,
+                        alt,
+                        reference_acc,
+                        var_type,
+                        frameshift,
+                        self._parse_parent_ids(parent_id),
                     ),
                 )
             except Exception as e:
-                print(f"Error processing row: {row}")
+                print(
+                    "Error processing row: "
+                    f"{(var_id, ref, start, end, alt, reference_acc, var_type, frameshift, parent_id)}"
+                )
                 print(f"Error file: {self.var_file_path}")
                 raise e
+        return variants
 
     def _import_seq(self, path):
         file_name = pathlib.Path(path).name

--- a/apps/backend/rest_api/data_entry/sample_import.py
+++ b/apps/backend/rest_api/data_entry/sample_import.py
@@ -11,7 +11,6 @@ import pandas as pd
 from rest_api.models import Alignment
 from rest_api.models import AminoAcidMutation
 from rest_api.models import CDS
-from rest_api.models import Gene
 from rest_api.models import NucleotideMutation
 from rest_api.models import Replicon
 from rest_api.models import Sample
@@ -140,8 +139,8 @@ class SonarImport:
     def get_mutation_objs_nt(
         self,
         nt_mutation_set: list[NucleotideMutation],
+        nt_mutation_lookup: dict[tuple, NucleotideMutation],
         replicon_cache: dict[str, Replicon | None],
-        gene_cache_by_var_pos: dict[Replicon | None, dict[int, dict[int, Gene | None]]],
         nt_mutation_alignment_relations: list[NucleotideMutation.alignments.through],
     ) -> dict[int, NucleotideMutation]:
         import_id_to_sample_mutations: dict[int, NucleotideMutation] = {}
@@ -155,19 +154,6 @@ class SonarImport:
                         )
                     )
                 replicon = replicon_cache[var_raw.replicon_or_cds_accession]
-                if not replicon in gene_cache_by_var_pos:
-                    gene_cache_by_var_pos[replicon] = {}
-                if not var_raw.start in gene_cache_by_var_pos[replicon]:
-                    gene_cache_by_var_pos[replicon][var_raw.start] = {}
-                if not var_raw.end in gene_cache_by_var_pos[replicon][var_raw.start]:
-                    gene_cache_by_var_pos[replicon][var_raw.start][var_raw.end] = (
-                        Gene.objects.filter(
-                            replicon=replicon,
-                            start__gte=var_raw.start,
-                            end__lte=var_raw.end,
-                        ).first()
-                    )
-                gene = gene_cache_by_var_pos[replicon][var_raw.start][var_raw.end]
                 # in DEL, we dont keep REF in the database.
                 if var_raw.alt is None:
                     var_raw.ref = ""
@@ -180,15 +166,18 @@ class SonarImport:
                     "replicon": self.replicon,
                     "is_frameshift": var_raw.frameshift,
                 }
-                mutation = next(
-                    filter(
-                        lambda x: self.is_same_mutation(mutation_data, x),
-                        nt_mutation_set,
-                    ),
-                    None,
+                mutation_key = (
+                    mutation_data["ref"],
+                    mutation_data["alt"],
+                    mutation_data["start"],
+                    mutation_data["end"],
+                    mutation_data["replicon"].pk if mutation_data["replicon"] else None,
+                    mutation_data["is_frameshift"],
                 )
+                mutation = nt_mutation_lookup.get(mutation_key)
                 if not mutation:
                     mutation = NucleotideMutation(**mutation_data)
+                    nt_mutation_lookup[mutation_key] = mutation
                     nt_mutation_set.append(mutation)
                 nt_mutation_alignment_relations.append(
                     NucleotideMutation.alignments.through(
@@ -206,6 +195,7 @@ class SonarImport:
     def get_mutation_objs_cds_and_parent_relations(
         self,
         cds_mutation_set: list[AminoAcidMutation],
+        cds_mutation_lookup: dict[tuple, AminoAcidMutation],
         gene_cache_by_accession: dict[str, CDS | None],
         parent_id_mapping: dict[int, NucleotideMutation],
         aa_mutation_alignment_relations: list[AminoAcidMutation.alignments.through],
@@ -234,15 +224,17 @@ class SonarImport:
                     "start": var_raw.start if var_raw.start else 0,
                     "end": var_raw.end if var_raw.end else 0,
                 }
-                mutation = next(
-                    filter(
-                        lambda x: self.is_same_mutation(mutation_data, x),
-                        cds_mutation_set,
-                    ),
-                    None,
+                mutation_key = (
+                    mutation_data["cds"].pk if mutation_data["cds"] else None,
+                    mutation_data["ref"],
+                    mutation_data["alt"],
+                    mutation_data["start"],
+                    mutation_data["end"],
                 )
+                mutation = cds_mutation_lookup.get(mutation_key)
                 if not mutation:
                     mutation = AminoAcidMutation(**mutation_data)
+                    cds_mutation_lookup[mutation_key] = mutation
                     cds_mutation_set.append(mutation)
                 aa_mutation_alignment_relations.append(
                     AminoAcidMutation.alignments.through(

--- a/apps/cli/src/sonar_cli/utils.py
+++ b/apps/cli/src/sonar_cli/utils.py
@@ -772,27 +772,34 @@ class sonarUtils:
         """Bundle up the data to be sent to the backend and send it"""
 
         files_to_compress = []
-        added_parquet_files = set()
+        sample_batch = []
+        sample_batch_rel_path = f"sample_batches/chunk-{chunk_number:06d}.samplebatch"
+        variant_batch_frames = []
+        variant_batch_rel_path = f"var_batches/chunk-{chunk_number:06d}.parquet"
         for kwargs in sample_list:
-            var_parquet_file = kwargs["var_parquet_file"]
-            sample_dict = kwargs
+            var_parquet_file = kwargs.get("var_parquet_file")
+            sample_dict = dict(kwargs)
+            if var_parquet_file:
+                var_df = pd.read_parquet(var_parquet_file)
+                var_df.insert(0, "sample_name", sample_dict["name"])
+                variant_batch_frames.append(var_df)
+                sample_dict["var_batch_file"] = variant_batch_rel_path
+                sample_dict["var_batch_sample_name"] = sample_dict["name"]
+                sample_dict["var_parquet_file"] = None
 
-            # Serialize the sample dictionary to bytes
-            sample_bytes = pickle.dumps(sample_dict)
-
-            # Append the serialized sample dictionary to the files to compress
-            files_to_compress.append(
-                (
-                    f"samples/{get_fname(kwargs['name'], extension='.sample', enable_parent_dir=True)}",
-                    sample_bytes,
-                )
+            sample_batch.append(sample_dict)
+        files_to_compress.append((sample_batch_rel_path, pickle.dumps(sample_batch)))
+        if variant_batch_frames:
+            variant_batch_bytes = BytesIO()
+            pd.concat(variant_batch_frames).to_parquet(
+                variant_batch_bytes,
+                compression="zstd",
+                compression_level=10,
+                index=False,
             )
-            # Deduplicate parquet files: samples with identical sequences share the same
-            # seqhash and therefore the same parquet file path. Adding it twice would
-            # produce a "Duplicate name" warning from zipfile.
-            if var_parquet_file not in added_parquet_files:
-                files_to_compress.append(var_parquet_file)
-                added_parquet_files.add(var_parquet_file)
+            files_to_compress.append(
+                (variant_batch_rel_path, variant_batch_bytes.getvalue())
+            )
 
         # Create a zip file without writing to disk
         compressed_data = BytesIO()


### PR DESCRIPTION
## Summary

This combines the four import runtime PRs into one reviewable PR:

- Avoid Redis pubsub result waits in Celery import result collection.
- Remove dead per-mutation `Gene` lookup and use dict-based NT/CDS mutation de-duplication.
- Speed up variant parquet parsing by reading only needed columns and using tuple iteration.
- Batch sample metadata and variant parquet files in CLI upload/import archives, while keeping old per-sample archive formats as fallback.

## Why

Large sample imports were spending substantial time in Celery result waits, repeated mutation construction lookups, pandas row conversion, and opening/extracting many tiny files. These changes keep import behavior compatible while reducing backend import overhead.

## Validation

- `python -m py_compile apps/backend/rest_api/data_entry/sample_entry_job.py`
- `python -m py_compile apps/backend/rest_api/data_entry/sample_import.py apps/backend/rest_api/data_entry/sample_entry_job.py`
- `python -m py_compile apps/backend/rest_api/data_entry/sample_import.py`
- `python -m py_compile apps/backend/rest_api/data_entry/sample_import.py apps/backend/rest_api/data_entry/sample_entry_job.py apps/cli/src/sonar_cli/utils.py`
- pre-commit hooks ran for each included commit

## Notes

This PR intentionally leaves out the temporary profiling and benchmark scaffolding from the investigation branch.